### PR TITLE
fixed rubik font preloading that was causing visual glitches in firefox

### DIFF
--- a/src/app/services/critical-resource-preloader.service.ts
+++ b/src/app/services/critical-resource-preloader.service.ts
@@ -67,8 +67,8 @@ export class CriticalResourcePreloaderService {
 
     // Preload critical Rubik font weights
     const criticalFonts = [
-      'https://fonts.gstatic.com/s/rubik/v28/iJWZBXyIfDnIV5PNhY1KTN7Z-Yh-B4iFVUUzdYPFkaVNA6w.woff2', // Regular 400
-      'https://fonts.gstatic.com/s/rubik/v28/iJWZBXyIfDnIV5PNhY1KTN7Z-Yh-B4iFVkUydYPFkaVNA6w.woff2', // Medium 500
+      'https://fonts.gstatic.com/s/rubik/v31/iJWEBXyIfDnIV7nEnXu61F3f.woff2', // Regular 400
+      'https://fonts.gstatic.com/s/rubik/v31/iJWEBXyIfDnIV7nEnXu61F3f.woff2', // Medium 500
     ];
 
     criticalFonts.forEach(fontUrl => {

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
     <link rel="dns-prefetch" href="https://googletagmanager.com">
     
     <!-- Ultra-optimized font loading with subsetting and critical path optimization -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;700&display=swap&text=QuranAppsDirectoryمجتمعإتقانلتقنياتالقرآناكتشفأفضلتطبيقاتالمصحفالتفسيرالتلاوةالتحفيظوالتدبر" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;700&display=swap" rel="stylesheet"></noscript>
     
     <!-- Font fallback with perfect metrics matching to prevent CLS -->


### PR DESCRIPTION
old
<img width="1037" height="160" alt="Screenshot_20251013_163152" src="https://github.com/user-attachments/assets/f8254986-0a5d-4ac0-9224-302ac95cdc07" />

new
<img width="978" height="160" alt="image" src="https://github.com/user-attachments/assets/b1ab18c2-3c85-40d5-bc44-c9f0c892f41f" />

check the ه in both images, this is happening on firefox becuase of the font precaching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preloaded Rubik font assets to a newer version to keep font resources current.
  * Adjusted font preload URLs to remove text subset restrictions, ensuring the full character set is available.

* **Style**
  * Improves font rendering consistency across pages with broader character support and more reliable loading.

No functional changes to user workflows; visual appearance remains the same, with potential minor improvements to text rendering and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->