### PR TITLE
feat(monitoring): add Sentry tunnel to bypass ad blockers

### DIFF
--- a/backend/apps/api/sentry_tunnel.py
+++ b/backend/apps/api/sentry_tunnel.py
@@ -1,0 +1,108 @@
+"""
+Sentry Tunnel - Proxy Sentry requests through Django backend.
+
+This bypasses ad blockers and CORS issues by routing Sentry
+requests through our own server instead of directly to sentry.io.
+
+Reference: https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option
+"""
+
+import json
+import logging
+import requests
+from django.http import HttpResponse, HttpResponseBadRequest
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+
+logger = logging.getLogger(__name__)
+
+# Allowed Sentry hosts (security: only proxy to official Sentry servers)
+ALLOWED_SENTRY_HOSTS = [
+    "sentry.io",
+    "ingest.sentry.io",
+    "ingest.de.sentry.io",  # EU data center
+    "ingest.us.sentry.io",  # US data center
+]
+
+
+@csrf_exempt
+@require_POST
+def sentry_tunnel(request):
+    """
+    Tunnel endpoint that forwards Sentry events to Sentry's ingest API.
+
+    The frontend sends Sentry envelopes here instead of directly to sentry.io,
+    allowing us to bypass ad blockers and CORS restrictions.
+
+    Security measures:
+    - Only allows POST requests
+    - Validates that the DSN host is an official Sentry server
+    - Extracts project ID from the envelope to construct the target URL
+    """
+    try:
+        # Get the raw envelope body
+        envelope = request.body
+
+        if not envelope:
+            return HttpResponseBadRequest("Empty request body")
+
+        # Parse the envelope header (first line contains the DSN info)
+        # Envelope format: header\nitem_header\nitem_payload\n...
+        try:
+            header_end_index = envelope.index(b'\n')
+            header = json.loads(envelope[:header_end_index])
+        except (ValueError, json.JSONDecodeError) as e:
+            return HttpResponseBadRequest(f"Invalid envelope header: {e}")
+
+        # Extract DSN from header
+        dsn = header.get("dsn")
+        if not dsn:
+            return HttpResponseBadRequest("Missing DSN in envelope header")
+
+        # Parse DSN to extract host and project ID
+        # DSN format: https://<key>@<host>/<project_id>
+        try:
+            # Remove protocol
+            dsn_without_protocol = dsn.split("://")[1]
+            # Split by @ to get host/project part
+            host_and_project = dsn_without_protocol.split("@")[1]
+            # Extract host and project ID
+            parts = host_and_project.split("/")
+            host = parts[0]
+            project_id = parts[1]
+        except (IndexError, ValueError) as e:
+            return HttpResponseBadRequest(f"Invalid DSN format: {e}")
+
+        # Security check: only allow official Sentry hosts
+        if not any(allowed in host for allowed in ALLOWED_SENTRY_HOSTS):
+            return HttpResponseBadRequest(f"Invalid Sentry host: {host}")
+
+        # Construct the Sentry ingest URL
+        sentry_url = f"https://{host}/api/{project_id}/envelope/"
+
+        # Forward the envelope to Sentry
+        try:
+            response = requests.post(
+                sentry_url,
+                data=envelope,
+                headers={
+                    "Content-Type": "application/x-sentry-envelope",
+                },
+                timeout=10,
+            )
+
+            return HttpResponse(
+                response.content,
+                status=response.status_code,
+                content_type=response.headers.get("Content-Type", "application/json"),
+            )
+        except requests.Timeout:
+            return HttpResponse("Sentry request timeout", status=504)
+        except requests.RequestException as e:
+            logger.warning(f"Sentry tunnel request failed: {e}")
+            return HttpResponse("Sentry request failed", status=502)
+
+    except Exception as e:
+        logger.error(f"Sentry tunnel error: {e}")
+        return HttpResponse("Internal server error", status=500)

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -10,6 +10,7 @@ from django.http import JsonResponse
 from django.utils import timezone
 from apps.api.urls import api as ninja_api
 from apps.api.views import ScalarDocumentationView
+from apps.api.sentry_tunnel import sentry_tunnel
 
 
 def health_check(request):
@@ -58,6 +59,9 @@ def health_check(request):
 urlpatterns = [
     # Health check endpoint (for monitoring/load balancers)
     path('health/', health_check, name='health_check'),
+
+    # Sentry tunnel (proxies Sentry requests to bypass ad blockers)
+    path('api/sentry-tunnel/', sentry_tunnel, name='sentry_tunnel'),
 
     # Admin interface
     path('admin/', admin.site.urls),

--- a/src/environments/environment.develop.ts
+++ b/src/environments/environment.develop.ts
@@ -20,6 +20,7 @@ export const environment = {
   sentry: {
     enabled: false,
     dsn: '',
+    tunnel: '',
     environment: 'develop',
     tracesSampleRate: 1.0,
     replaysSessionSampleRate: 0,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -19,6 +19,7 @@ export const environment = {
   sentry: {
     enabled: true,
     dsn: 'https://10ae32f7f36add568917f16d53562358@o4510669335232512.ingest.de.sentry.io/4510669357842512',
+    tunnel: 'https://qad-backend-api-production.up.railway.app/api/sentry-tunnel/',
     environment: 'production',
     tracesSampleRate: 0.1,
     replaysSessionSampleRate: 0.1,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -20,6 +20,7 @@ export const environment = {
   sentry: {
     enabled: true,
     dsn: 'https://10ae32f7f36add568917f16d53562358@o4510669335232512.ingest.de.sentry.io/4510669357842512',
+    tunnel: 'https://qad-backend-api-staging.up.railway.app/api/sentry-tunnel/',
     environment: 'staging',
     tracesSampleRate: 1.0,
     replaysSessionSampleRate: 0.1,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -20,6 +20,7 @@ export const environment = {
   sentry: {
     enabled: false,
     dsn: '',
+    tunnel: '',
     environment: 'development',
     tracesSampleRate: 1.0,
     replaysSessionSampleRate: 0,

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ if (environment.sentry.enabled && environment.sentry.dsn) {
     dsn: environment.sentry.dsn,
     environment: environment.sentry.environment,
     release: `quran-apps-directory@${environment.version}`,
+    // Tunnel routes requests through our backend to bypass ad blockers
+    ...(environment.sentry.tunnel && { tunnel: environment.sentry.tunnel }),
     integrations: [
       Sentry.browserTracingIntegration(),
       Sentry.replayIntegration({


### PR DESCRIPTION
## Summary
Implements a Sentry tunnel to route error tracking requests through our Django backend, bypassing ad blockers and CORS issues.

## Changes

### Backend (Django)
- **NEW** `backend/apps/api/sentry_tunnel.py` - Tunnel endpoint that:
  - Receives Sentry envelope from frontend
  - Validates DSN host against allowed Sentry servers (security)
  - Forwards envelope to Sentry's ingest API
- **MODIFIED** `backend/config/urls.py` - Added `/api/sentry-tunnel/` route

### Frontend (Angular)
- **MODIFIED** `src/main.ts` - Added `tunnel` option to Sentry.init()
- **MODIFIED** Environment files - Added tunnel URLs for staging/production

## How It Works
```
Frontend → /api/sentry-tunnel/ → Django Backend → Sentry Ingest API
```

## Benefits
- 100% error capture (no ad blocker interference)
- No CORS errors in browser console
- Same-origin requests only

## Test Plan
- [ ] Deploy backend to staging
- [ ] Verify `/api/sentry-tunnel/` endpoint responds
- [ ] Deploy frontend to staging
- [ ] Trigger an error and verify it appears in Sentry dashboard
- [ ] Confirm no CORS errors in browser console