### PR TITLE
fix(cache): handle stale chunk errors after deployments

### DIFF
--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -1,0 +1,39 @@
+/**
+ * Cloudflare Pages Function - Asset 404 Handler
+ *
+ * Problem: Cloudflare's _redirects catch-all returns HTML for missing JS/CSS files.
+ * This causes "expected expression, got '<'" errors when browsers try to parse HTML as JS.
+ *
+ * Solution: Intercept static asset requests and return proper 404 if the file doesn't exist.
+ */
+
+interface CFContext {
+  request: Request;
+  next: () => Promise<Response>;
+}
+
+export const onRequest = async (context: CFContext): Promise<Response> => {
+  const { request, next } = context;
+  const path = new URL(request.url).pathname;
+
+  // Check if this is a static asset request (JS, CSS, fonts, source maps)
+  const isStaticAsset = /\.(js|css|map|woff2?|ttf|eot)$/i.test(path);
+
+  if (isStaticAsset) {
+    const response = await next();
+
+    // If Cloudflare returned HTML for a missing asset (catch-all redirect), return 404 instead
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('text/html')) {
+      return new Response('Not found', {
+        status: 404,
+        headers: { 'Content-Type': 'text/plain' }
+      });
+    }
+
+    return response;
+  }
+
+  // For non-static assets, let the normal routing handle it
+  return next();
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,4 +28,28 @@ if (environment.sentry.enabled && environment.sentry.dsn) {
 console.log('📍 main.ts: Bootstrapping application');
 
 bootstrapApplication(AppComponent, appConfig)
-  .catch(err => console.error('Bootstrap error:', err));
+  .catch(err => {
+    console.error('Bootstrap error:', err);
+
+    // Detect stale chunk errors (syntax error from HTML response or chunk load failure)
+    // This happens when cached JS filenames no longer exist after deployment
+    const isChunkError = err.message && (
+      err.message.includes('Loading chunk') ||
+      err.message.includes('ChunkLoadError') ||
+      err.message.includes("expected expression, got '<'") ||
+      err.message.includes('Unexpected token')
+    );
+
+    if (isChunkError) {
+      // Clear service worker cache and unregister workers
+      if ('caches' in window) {
+        caches.keys().then(names => names.forEach(name => caches.delete(name)));
+      }
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.getRegistrations()
+          .then(regs => regs.forEach(reg => reg.unregister()));
+      }
+      // Silent reload - user just sees page refresh with fresh assets
+      window.location.reload();
+    }
+  });


### PR DESCRIPTION
## Summary
- Add Cloudflare Pages Function (`functions/[[path]].ts`) to return proper 404 for missing JS/CSS files instead of HTML
- Add bootstrap error handler in `main.ts` for automatic client-side recovery when chunk errors occur

## Problem
After deployments, users with cached old JS chunk filenames see a blank page with:
```
Uncaught SyntaxError: expected expression, got '<'
```
This happens because Cloudflare's `_redirects` catch-all returns HTML for missing JS files instead of 404.

## Solution
**Layer 1 - Server-side (root cause fix):**
Cloudflare Pages Function intercepts static asset requests and returns proper 404 if the file doesn't exist (instead of HTML from catch-all redirect).

**Layer 2 - Client-side (graceful recovery):**
Bootstrap error handler detects chunk loading errors, clears service worker cache, and silently reloads the page.

## Test plan
- [ ] Deploy to staging and verify normal operation
- [ ] After deployment, clear browser cache and verify page loads correctly
- [ ] Manually request a non-existent JS file URL - should return 404 (not HTML)
- [ ] Test with stale cached assets to verify auto-recovery works