### PR TITLE
fix(migration): use correct field name logo_url

### DIFF
--- a/backend/apps/migrations/0012_fix_broken_developer_logos.py
+++ b/backend/apps/migrations/0012_fix_broken_developer_logos.py
@@ -19,8 +19,8 @@ def fix_developer_logos(apps, schema_editor):
         ('Quranic Recitations Collection', f'{R2_BASE}/70_Quranic Recitations Collection/developer_logo.svg'),
     ]
 
-    for name, logo_url in updates:
-        updated = Developer.objects.filter(name_en=name).update(logo=logo_url)
+    for name, new_logo_url in updates:
+        updated = Developer.objects.filter(name_en=name).update(logo_url=new_logo_url)
         if updated:
             print(f"  Updated logo for: {name}")
         else:


### PR DESCRIPTION
## Summary
- Fix migration `0012_fix_broken_developer_logos.py` to use correct field name `logo_url` instead of `logo`
- This was causing Railway staging deployments to crash with `FieldDoesNotExist: Developer has no field named 'logo'`

## Test plan
- [ ] Railway staging should deploy successfully after merge
- [ ] Migration should run without errors
- [ ] Staging backend should return healthy response