### PR TITLE
fix(og-tags): Correct image dimensions for WhatsApp compliance

### DIFF
--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -41,6 +41,8 @@ interface OGTags {
   title: string;
   description: string;
   image: string;
+  imageWidth?: number;
+  imageHeight?: number;
   url: string;
   type: string;
   locale: string;
@@ -113,10 +115,13 @@ const generateOGTags = (route: RouteInfo, data: any): OGTags => {
       ? (data.short_description_ar || data.description_ar)
       : (data.short_description_en || data.description_en);
 
+    const hasAppIcon = !!data.application_icon;
     return {
       title: title || 'Quran App',
       description: description || '',
       image: data.application_icon || DEFAULT_IMAGE,
+      imageWidth: hasAppIcon ? 512 : 1200,
+      imageHeight: hasAppIcon ? 512 : 630,
       url: `${BASE_URL}/${route.lang}/app/${data.slug}`,
       type: 'website',
       locale: route.lang === 'ar' ? 'ar_SA' : 'en_US',
@@ -132,10 +137,13 @@ const generateOGTags = (route: RouteInfo, data: any): OGTags => {
       ? `اكتشف تطبيقات ${data.name_ar || data.name_en}`
       : `Discover apps by ${data.name_en || data.name_ar}`;
 
+    const hasLogo = !!data.logo_url;
     return {
       title,
       description,
       image: data.logo_url || DEFAULT_IMAGE,
+      imageWidth: hasLogo ? 512 : 1200,
+      imageHeight: hasLogo ? 512 : 630,
       url: `${BASE_URL}/${route.lang}/developer/${data.slug}`,
       type: 'website',
       locale: route.lang === 'ar' ? 'ar_SA' : 'en_US',
@@ -153,6 +161,8 @@ const generateOGTags = (route: RouteInfo, data: any): OGTags => {
       title: title || 'Category',
       description,
       image: DEFAULT_IMAGE,
+      imageWidth: 1200,
+      imageHeight: 630,
       url: `${BASE_URL}/${route.lang}/${route.slug}`,
       type: 'website',
       locale: route.lang === 'ar' ? 'ar_SA' : 'en_US',
@@ -168,6 +178,8 @@ const generateOGTags = (route: RouteInfo, data: any): OGTags => {
       ? 'الدليل الشامل لأفضل تطبيقات القرآن الكريم - تطبيقات المصحف، التفسير، التلاوة، التحفيظ والتدبر'
       : 'Discover the best Quran applications - Mushaf, Tafsir, Recitation, Memorization and more',
     image: DEFAULT_IMAGE,
+    imageWidth: 1200,
+    imageHeight: 630,
     url: `${BASE_URL}/${route.lang}`,
     type: 'website',
     locale: route.lang === 'ar' ? 'ar_SA' : 'en_US',
@@ -176,15 +188,16 @@ const generateOGTags = (route: RouteInfo, data: any): OGTags => {
 
 // HTML injection
 const injectOGTags = (html: string, tags: OGTags): string => {
+  const widthTag = tags.imageWidth ? `\n    <meta property="og:image:width" content="${tags.imageWidth}" />` : '';
+  const heightTag = tags.imageHeight ? `\n    <meta property="og:image:height" content="${tags.imageHeight}" />` : '';
+
   const ogTagsHtml = `<!-- Dynamic OG Tags -->
     <meta property="og:type" content="${tags.type}" />
     <meta property="og:url" content="${tags.url}" />
     <meta property="og:title" content="${escapeHtml(tags.title)}" />
     <meta property="og:description" content="${escapeHtml(tags.description)}" />
     <meta property="og:image" content="${tags.image}" />
-    <meta property="og:image:alt" content="${escapeHtml(tags.title)}" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="${escapeHtml(tags.title)}" />${widthTag}${heightTag}
     <meta property="og:locale" content="${tags.locale}" />
     <meta property="og:site_name" content="Quran Apps Directory" />
     <!-- Twitter Card -->

--- a/src/index.html
+++ b/src/index.html
@@ -315,7 +315,7 @@
     <!-- Open Graph Meta Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://quran-apps.itqan.dev/" />
-    <meta property="og:title" content="دليل التطبيقات القرآنية الشامل - أفضل تطبيقات القرآن الكريم" />
+    <meta property="og:title" content="دليل التطبيقات القرآنية الشامل" />
     <meta property="og:description" content="الدليل الشامل لأفضل تطبيقات القرآن الكريم - تطبيقات المصحف، التفسير، التلاوة، التحفيظ والتدبر. اكتشف أكثر من 100 تطبيق قرآني مجاني ومدفوع" />
     <meta property="og:image" content="https://quran-apps.itqan.dev/assets/images/Social-Media-Thumnail.webp" />
     <meta property="og:image:alt" content="دليل التطبيقات القرآنية الشامل" />
@@ -328,7 +328,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://quran-apps.itqan.dev/" />
-    <meta property="twitter:title" content="دليل التطبيقات القرآنية الشامل - أفضل تطبيقات القرآن الكريم" />
+    <meta property="twitter:title" content="دليل التطبيقات القرآنية الشامل" />
     <meta property="twitter:description" content="الدليل الشامل لأفضل تطبيقات القرآن الكريم - تطبيقات المصحف، التفسير، التلاوة، التحفيظ والتدبر" />
     <meta property="twitter:image" content="https://quran-apps.itqan.dev/assets/images/Social-Media-Thumnail.webp" />
     <meta property="twitter:image:alt" content="دليل التطبيقات القرآنية الشامل" />


### PR DESCRIPTION
## Summary
- Fixed WhatsApp link preview compliance by declaring correct image dimensions
- App icons now declare 512×512 (actual size) instead of hardcoded 1200×630
- Default social thumbnails correctly declare 1200×630
- Shortened og:title to meet WhatsApp's 65-character limit

## Test plan
- [ ] Test with Facebook Sharing Debugger: https://developers.facebook.com/tools/debug/
- [ ] Share link on WhatsApp and verify preview shows correctly
- [ ] Test app page: `/en/app/surah`
- [ ] Test developer page: `/en/developer/quran-com`
- [ ] Test category page: `/en/mushaf`