### PR TITLE
Analytics Dashboard Summary - Add bulk analytics endpoint

### DIFF
--- a/backend/apps/api/analytics.py
+++ b/backend/apps/api/analytics.py
@@ -17,6 +17,10 @@ from pydantic import BaseModel, Field
 from ..models import App, AppViewEvent
 
 
+# Period type for dashboard summary
+PeriodType = Literal["today", "7d", "30d", "90d", "all"]
+
+
 router = Router(tags=["Analytics"])
 
 
@@ -59,6 +63,30 @@ class AnalyticsResponse(BaseModel):
     device_breakdown: List[DeviceBreakdownItem]
     country_breakdown: List[CountryBreakdownItem]
     top_referrers: List[ReferrerItem]
+
+
+class TopAppItem(BaseModel):
+    """Top app item for dashboard summary."""
+    app_id: str
+    app_slug: str
+    app_name_en: str
+    app_name_ar: str
+    view_count: int
+    unique_sessions: int
+
+
+class DashboardSummaryResponse(BaseModel):
+    """Dashboard summary response schema."""
+    total_views: int
+    total_unique_sessions: int
+    total_apps: int
+    period: str
+    date_start: str
+    date_end: str
+    top_apps: List[TopAppItem]
+    device_breakdown: List[DeviceBreakdownItem]
+    country_breakdown: List[CountryBreakdownItem]
+    time_series: List[TimeSeriesItem]
 
 
 @router.get("/{app_id}/analytics", response=AnalyticsResponse)
@@ -220,4 +248,222 @@ def get_app_analytics(
         device_breakdown=device_breakdown,
         country_breakdown=country_breakdown,
         top_referrers=top_referrers,
+    )
+
+
+def resolve_date_range(
+    period: Optional[PeriodType],
+    date_start: Optional[str],
+    date_end: Optional[str]
+) -> tuple[datetime, datetime, str]:
+    """
+    Resolve date range from period preset or custom dates.
+
+    Custom dates take precedence over period presets.
+
+    Returns:
+        Tuple of (start_date, end_date, period_label)
+    """
+    now = timezone.now()
+
+    # Custom dates override period
+    if date_start or date_end:
+        if date_end:
+            try:
+                end_dt = datetime.fromisoformat(date_end.replace('Z', '+00:00'))
+                if timezone.is_naive(end_dt):
+                    end_dt = timezone.make_aware(end_dt)
+            except ValueError:
+                end_dt = datetime.strptime(date_end, "%Y-%m-%d")
+                end_dt = timezone.make_aware(end_dt)
+            end_dt = end_dt.replace(hour=23, minute=59, second=59)
+        else:
+            end_dt = now.replace(hour=23, minute=59, second=59)
+
+        if date_start:
+            try:
+                start_dt = datetime.fromisoformat(date_start.replace('Z', '+00:00'))
+                if timezone.is_naive(start_dt):
+                    start_dt = timezone.make_aware(start_dt)
+            except ValueError:
+                start_dt = datetime.strptime(date_start, "%Y-%m-%d")
+                start_dt = timezone.make_aware(start_dt)
+            start_dt = start_dt.replace(hour=0, minute=0, second=0)
+        else:
+            start_dt = (now - timedelta(days=30)).replace(hour=0, minute=0, second=0)
+
+        return start_dt, end_dt, "custom"
+
+    # Period presets
+    period = period or "30d"
+    end_dt = now.replace(hour=23, minute=59, second=59)
+
+    if period == "today":
+        start_dt = now.replace(hour=0, minute=0, second=0)
+    elif period == "7d":
+        start_dt = (now - timedelta(days=7)).replace(hour=0, minute=0, second=0)
+    elif period == "30d":
+        start_dt = (now - timedelta(days=30)).replace(hour=0, minute=0, second=0)
+    elif period == "90d":
+        start_dt = (now - timedelta(days=90)).replace(hour=0, minute=0, second=0)
+    elif period == "all":
+        # Get earliest event or fallback to 1 year ago
+        earliest = AppViewEvent.objects.order_by('viewed_at').first()
+        if earliest:
+            start_dt = earliest.viewed_at.replace(hour=0, minute=0, second=0)
+        else:
+            start_dt = (now - timedelta(days=365)).replace(hour=0, minute=0, second=0)
+    else:
+        start_dt = (now - timedelta(days=30)).replace(hour=0, minute=0, second=0)
+
+    return start_dt, end_dt, period
+
+
+# Create a separate router for dashboard summary (mounted at /api/analytics)
+dashboard_router = Router(tags=["Analytics"])
+
+
+@dashboard_router.get("/summary", response=DashboardSummaryResponse)
+def get_dashboard_summary(
+    request,
+    period: Optional[PeriodType] = Query("30d", description="Preset period: today, 7d, 30d, 90d, all"),
+    date_start: Optional[str] = Query(None, description="Custom start date (ISO format, overrides period)"),
+    date_end: Optional[str] = Query(None, description="Custom end date (ISO format, overrides period)"),
+    group_by: Literal["hour", "day", "week", "month"] = Query("day", description="Time series grouping"),
+):
+    """
+    Get aggregate analytics across all apps.
+
+    Returns dashboard summary with total views, top apps, device/country breakdowns,
+    and time series data.
+
+    Args:
+        period: Preset period (today, 7d, 30d, 90d, all). Default: 30d
+        date_start: Custom start date (ISO format). Overrides period.
+        date_end: Custom end date (ISO format). Overrides period.
+        group_by: Time series grouping (hour, day, week, month)
+
+    Returns:
+        DashboardSummaryResponse with aggregate analytics
+    """
+    # Resolve date range
+    start_date, end_date, period_label = resolve_date_range(period, date_start, date_end)
+
+    # Base queryset filtered by date range
+    events = AppViewEvent.objects.filter(
+        viewed_at__gte=start_date,
+        viewed_at__lte=end_date,
+    )
+
+    # Total views
+    total_views = events.count()
+
+    # Unique sessions (excluding null session_ids)
+    total_unique_sessions = events.exclude(
+        session_id__isnull=True
+    ).exclude(
+        session_id=''
+    ).values('session_id').distinct().count()
+
+    # Total apps with views in this period
+    total_apps = events.values('app').distinct().count()
+
+    # Top apps by view count (top 10)
+    top_apps_data = (
+        events
+        .values('app')
+        .annotate(view_count=Count('id'))
+        .order_by('-view_count')[:10]
+    )
+
+    top_apps = []
+    for item in top_apps_data:
+        app = App.objects.filter(id=item['app']).first()
+        if app:
+            # Count unique sessions for this app
+            app_sessions = events.filter(app=app).exclude(
+                session_id__isnull=True
+            ).exclude(
+                session_id=''
+            ).values('session_id').distinct().count()
+
+            top_apps.append(TopAppItem(
+                app_id=str(app.id),
+                app_slug=app.slug,
+                app_name_en=app.name_en,
+                app_name_ar=app.name_ar or '',
+                view_count=item['view_count'],
+                unique_sessions=app_sessions,
+            ))
+
+    # Time series aggregation
+    trunc_func = {
+        "hour": TruncHour,
+        "day": TruncDay,
+        "week": TruncWeek,
+        "month": TruncMonth,
+    }[group_by]
+
+    time_series_data = (
+        events
+        .annotate(period=trunc_func('viewed_at'))
+        .values('period')
+        .annotate(count=Count('id'))
+        .order_by('period')
+    )
+
+    time_series = [
+        TimeSeriesItem(
+            date=item['period'].isoformat() if item['period'] else '',
+            count=item['count']
+        )
+        for item in time_series_data
+        if item['period']
+    ]
+
+    # Device breakdown
+    device_data = (
+        events
+        .values('device_type')
+        .annotate(count=Count('id'))
+        .order_by('-count')
+    )
+
+    device_breakdown = [
+        DeviceBreakdownItem(
+            device_type=item['device_type'] or 'unknown',
+            count=item['count'],
+            percentage=round((item['count'] / total_views * 100), 1) if total_views > 0 else 0
+        )
+        for item in device_data
+    ]
+
+    # Country breakdown (top 10)
+    country_data = (
+        events
+        .values('country_code')
+        .annotate(count=Count('id'))
+        .order_by('-count')[:10]
+    )
+
+    country_breakdown = [
+        CountryBreakdownItem(
+            country_code=item['country_code'],
+            count=item['count'],
+            percentage=round((item['count'] / total_views * 100), 1) if total_views > 0 else 0
+        )
+        for item in country_data
+    ]
+
+    return DashboardSummaryResponse(
+        total_views=total_views,
+        total_unique_sessions=total_unique_sessions,
+        total_apps=total_apps,
+        period=period_label,
+        date_start=start_date.strftime("%Y-%m-%d"),
+        date_end=end_date.strftime("%Y-%m-%d"),
+        top_apps=top_apps,
+        device_breakdown=device_breakdown,
+        country_breakdown=country_breakdown,
+        time_series=time_series,
     )

--- a/backend/apps/api/urls.py
+++ b/backend/apps/api/urls.py
@@ -10,7 +10,7 @@ from ninja.renderers import JSONRenderer
 from .controllers import router as apps_router, get_categories
 from .search import router as search_router
 from .admin_controllers import router as admin_router
-from .analytics import router as analytics_router
+from .analytics import router as analytics_router, dashboard_router
 from submissions.api.controllers import router as submissions_router
 
 
@@ -40,6 +40,7 @@ def list_categories(request):
 # Add routers to API
 api.add_router("/apps", apps_router)
 api.add_router("/apps", analytics_router)  # Analytics nested under /apps/{id}/analytics
+api.add_router("/analytics", dashboard_router)  # Dashboard summary at /api/analytics/summary
 api.add_router("/search", search_router)
 api.add_router("/categories", categories_router)
 api.add_router("/submissions", submissions_router)

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -289,6 +289,8 @@ CACHE_TIMEOUTS = {
     'APP_DETAIL': 600,    # 10 minutes
     'CATEGORY_LIST': 600, # 10 minutes
     'DEVELOPER_LIST': 600, # 10 minutes
+    'ANALYTICS_SUMMARY': 300,      # 5 minutes for dashboard
+    'ANALYTICS_SUMMARY_ALL': 900,  # 15 minutes for "all time" queries
 }
 
 


### PR DESCRIPTION
## Summary
- Add new `GET /api/analytics/summary` endpoint for aggregate analytics across all apps
- Support period presets: `today`, `7d`, `30d`, `90d`, `all`
- Support custom date ranges (override period presets)
- Support time series grouping: `hour`, `day`, `week`, `month`

## Test plan
- [ ] Test default period (30d): `curl "https://staging-url/api/analytics/summary"`
- [ ] Test preset periods: `?period=7d`, `?period=today`
- [ ] Test custom date range: `?date_start=2026-01-01&date_end=2026-01-13`
- [ ] Test grouping: `?group_by=week`

## Response includes
- `total_views`, `total_unique_sessions`, `total_apps`
- `top_apps` (top 10 by view count)
- `device_breakdown`, `country_breakdown`
- `time_series` data