### PR TITLE
fix: resolve memory leaks from unmanaged RxJS subscriptions (#232)

### DIFF
--- a/src/app/pages/app-detail/app-detail.component.ts
+++ b/src/app/pages/app-detail/app-detail.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   OnInit,
+  OnDestroy,
   AfterViewInit,
   ViewChild,
   ElementRef,
@@ -35,6 +36,8 @@ import { Nl2brPipe } from "../../pipes/nl2br.pipe";
 import { OptimizedImageComponent } from "../../components/optimized-image/optimized-image.component";
 import { SeoService } from "../../services/seo.service";
 import { environment } from "../../../environments/environment";
+import { Subject, of } from "rxjs";
+import { takeUntil, switchMap } from "rxjs/operators";
 // register Swiper custom elements
 register();
 
@@ -62,7 +65,7 @@ register();
   styleUrls: ["./app-detail.component.scss"],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
-export class AppDetailComponent implements OnInit, AfterViewInit {
+export class AppDetailComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild("swiperContainer") swiperContainer: any;
   @ViewChild("relatedCarousel") relatedCarousel!: ElementRef<HTMLDivElement>;
 
@@ -74,6 +77,7 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
   // Cache for star arrays to prevent NG0100 errors from creating new references on each change detection
   private starArrayCache = new Map<number, { fillPercent: number }[]>();
   private swiperInitAttempts = 0;
+  private destroy$ = new Subject<void>();
 
   swiperParams = {
     slidesPerView: "auto",
@@ -107,27 +111,29 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
   ) {
     this.currentLang = this.translateService.currentLang as "ar" | "en";
     // Subscribe to language changes
-    this.translateService.onLangChange.subscribe((event) => {
-      this.currentLang = event.lang as "en" | "ar";
-      console.log("🌐 DEBUG: Language changed to:", this.currentLang);
-      // Reinitialize swiper when language changes (same pattern as data load)
-      if (this.swiperContainer) {
-        console.log("🔄 DEBUG: Reinitializing Swiper after language change...");
-        this.hideSwiper = false;
-        setTimeout(() => {
-          this.hideSwiper = true;
-          console.log(
-            "🔄 DEBUG: Swiper container reset after language change, initializing...",
-          );
-        }, 50);
-        setTimeout(() => {
-          console.log(
-            "🔄 DEBUG: Final Swiper initialization after language change...",
-          );
-          this.initializeSwiper();
-        }, 100);
-      }
-    });
+    this.translateService.onLangChange
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((event) => {
+        this.currentLang = event.lang as "en" | "ar";
+        console.log("🌐 DEBUG: Language changed to:", this.currentLang);
+        // Reinitialize swiper when language changes (same pattern as data load)
+        if (this.swiperContainer) {
+          console.log("🔄 DEBUG: Reinitializing Swiper after language change...");
+          this.hideSwiper = false;
+          setTimeout(() => {
+            this.hideSwiper = true;
+            console.log(
+              "🔄 DEBUG: Swiper container reset after language change, initializing...",
+            );
+          }, 50);
+          setTimeout(() => {
+            console.log(
+              "🔄 DEBUG: Final Swiper initialization after language change...",
+            );
+            this.initializeSwiper();
+          }, 100);
+        }
+      });
   }
 
   private getBrowserLanguage(): "en" | "ar" {
@@ -146,7 +152,7 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
     }
 
     // Subscribe to route parameter changes (both lang and id)
-    this.route.params.subscribe((params) => {
+    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
       const newLang = params["lang"];
       const newId = params["id"];
 
@@ -170,7 +176,7 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
     });
 
     // Handle fragment navigation (e.g., #downloads)
-    this.route.fragment.subscribe((fragment) => {
+    this.route.fragment.pipe(takeUntil(this.destroy$)).subscribe((fragment) => {
       if (fragment === "downloads" && isPlatformBrowser(this.platformId)) {
         // Wait for app data to load and DOM to render
         setTimeout(() => {
@@ -178,6 +184,11 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
         }, 500);
       }
     });
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   private loadAppData(appParam: string) {
@@ -192,8 +203,9 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
       }
     }
 
-    this.appService.getAppById(appId).subscribe(
-      (app) => {
+    this.appService.getAppById(appId).pipe(
+      takeUntil(this.destroy$),
+      switchMap((app) => {
         if (app) {
           console.log("✅ DEBUG: App data loaded successfully:", app.Name_En);
           console.log(
@@ -213,13 +225,6 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
           this.app = app;
           this.cdr.detectChanges(); // Trigger immediate change detection
           console.log(app.categories);
-          if (app.categories.length > 0) {
-            this.appService
-              .getAppsByCategory(app.categories[0])
-              .subscribe((apps) => {
-                this.relevantApps = apps.filter((a) => a.id !== app.id);
-              });
-          }
 
           // Update SEO data after app is loaded
           this.updateSeoData();
@@ -243,14 +248,26 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
             "loading:",
             this.loading,
           );
+
+          // Flatten nested subscribe: fetch related apps via switchMap
+          if (app.categories.length > 0) {
+            return this.appService.getAppsByCategory(app.categories[0]);
+          }
         } else {
           console.error("❌ DEBUG: No app data returned for:", appParam);
         }
+        return of([]);
+      }),
+    ).subscribe({
+      next: (apps) => {
+        if (this.app) {
+          this.relevantApps = apps.filter((a) => a.id !== this.app!.id);
+        }
       },
-      (error) => {
+      error: (error) => {
         console.error("❌ DEBUG: Error loading app data:", error);
       },
-    );
+    });
   }
 
   // Add a method to handle navigation to a related app

--- a/src/app/pages/developer/developer.component.ts
+++ b/src/app/pages/developer/developer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, PLATFORM_ID, Inject } from '@angular/core';
+import { Component, OnInit, OnDestroy, PLATFORM_ID, Inject } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, RouterModule, Router } from '@angular/router';
@@ -12,6 +12,8 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AppService, QuranApp } from '../../services/app.service';
 import { Title, Meta } from '@angular/platform-browser';
 import { SeoService } from '../../services/seo.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-developer',
@@ -31,7 +33,7 @@ import { SeoService } from '../../services/seo.service';
   templateUrl: './developer.component.html',
   styleUrls: ['./developer.component.scss']
 })
-export class DeveloperComponent implements OnInit {
+export class DeveloperComponent implements OnInit, OnDestroy {
   developerApps: QuranApp[] = [];
   developerInfo: any = null;
   currentLang: 'en' | 'ar' = 'ar';
@@ -40,6 +42,7 @@ export class DeveloperComponent implements OnInit {
   developerParam = ''; // Store the full parameter (name_id)
   // Cache for star arrays to prevent NG0100 errors from creating new references on each change detection
   private starArrayCache = new Map<number, { fillPercent: number }[]>();
+  private destroy$ = new Subject<void>();
 
   constructor(
     @Inject(PLATFORM_ID) private readonly platformId: Object,
@@ -54,10 +57,12 @@ export class DeveloperComponent implements OnInit {
     console.log('🏗️ DeveloperComponent constructor called');
     this.currentLang = this.translateService.currentLang as 'ar' | 'en';
     // Subscribe to language changes
-    this.translateService.onLangChange.subscribe((event) => {
-      this.currentLang = event.lang as 'en' | 'ar';
-      this.updatePageTitle();
-    });
+    this.translateService.onLangChange
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((event) => {
+        this.currentLang = event.lang as 'en' | 'ar';
+        this.updatePageTitle();
+      });
   }
 
   ngOnInit() {
@@ -74,7 +79,7 @@ export class DeveloperComponent implements OnInit {
     }
 
     // Subscribe to route parameter changes
-    this.route.params.subscribe((params) => {
+    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
       console.log('🔄 Route params changed:', params);
       const newLang = params['lang'];
       const newDeveloperParam = params['developer'];
@@ -96,6 +101,11 @@ export class DeveloperComponent implements OnInit {
         console.log('⚠️ No developer param in route');
       }
     });
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   private loadDeveloperData(developerParam: string) {
@@ -129,18 +139,22 @@ export class DeveloperComponent implements OnInit {
     // Load from API using developer_id
     if (developerId) {
       console.log('📡 Fetching from API using developer_id:', developerId);
-      this.appService.getAppsByDeveloperId(developerId).subscribe(
-        (apps) => this.handleDeveloperAppsLoaded(apps),
-        (error) => this.handleDeveloperAppsError(error)
-      );
+      this.appService.getAppsByDeveloperId(developerId)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: (apps) => this.handleDeveloperAppsLoaded(apps),
+          error: (error) => this.handleDeveloperAppsError(error),
+        });
     } else {
       // No ID in URL - fall back to search by developer name
       const searchName = decodedName.replace(/-/g, ' ');
       console.log('📡 No developer ID, falling back to search by name:', searchName);
-      this.appService.getAppsByDeveloper(searchName).subscribe(
-        (apps) => this.handleDeveloperAppsLoaded(apps),
-        (error) => this.handleDeveloperAppsError(error)
-      );
+      this.appService.getAppsByDeveloper(searchName)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: (apps) => this.handleDeveloperAppsLoaded(apps),
+          error: (error) => this.handleDeveloperAppsError(error),
+        });
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #232 — Memory leaks from unmanaged RxJS subscriptions in `AppDetailComponent` and `DeveloperComponent`.

Both components created RxJS subscriptions (route params, language changes, HTTP calls) but never unsubscribed, causing subscriptions to accumulate across navigations and persist after component destruction.

### Changes

**AppDetailComponent** (`app-detail.component.ts`):
- Added `OnDestroy` lifecycle hook with `destroy$` Subject
- Piped `translateService.onLangChange` through `takeUntil(this.destroy$)` — prevents language change listener from persisting after navigation
- Piped `route.params` through `takeUntil(this.destroy$)` — prevents route parameter listener accumulation
- Piped `route.fragment` through `takeUntil(this.destroy$)` — prevents fragment navigation listener accumulation
- Piped `appService.getAppById()` through `takeUntil(this.destroy$)` — prevents in-flight HTTP requests from firing callbacks on a destroyed component
- **Flattened nested subscribe** in `loadAppData`: replaced inner `getAppsByCategory().subscribe()` with `switchMap` operator, eliminating the nested subscription anti-pattern
- Used modern observer object form `subscribe({ next, error })` instead of deprecated positional arguments

**DeveloperComponent** (`developer.component.ts`):
- Added `OnDestroy` lifecycle hook with `destroy$` Subject
- Piped `translateService.onLangChange` through `takeUntil(this.destroy$)`
- Piped `route.params` through `takeUntil(this.destroy$)`
- Piped `appService.getAppsByDeveloperId()` through `takeUntil(this.destroy$)` — prevents HTTP callback on destroyed component
- Piped `appService.getAppsByDeveloper()` through `takeUntil(this.destroy$)` — prevents HTTP callback on destroyed component
- Used modern observer object form for `.subscribe()` calls

### Pattern Consistency

The `destroy$` + `takeUntil` + `ngOnDestroy` pattern is consistent with the existing implementation in `AppListComponent` (lines 91, 137-142, 278-285), which already correctly manages subscription lifecycle.

### Verification

- ✅ `ng build --configuration=development` passes with zero errors
- ✅ All 7 previously unmanaged subscriptions are now guarded
- ✅ Nested subscribe anti-pattern eliminated via `switchMap`
- ✅ No deprecated RxJS patterns introduced (uses observer object form)
- ✅ Code reviewed by automated reviewer — caught 2 additional unguarded HTTP subscriptions in `DeveloperComponent.loadDeveloperData()` that were added in the fix
- ✅ Stress-tested by grumpy-tester agent — identified pre-existing issues (setTimeout callbacks, navigateToApp array clearing) that are outside the scope of this fix

## Test Plan

- [ ] Navigate to an app detail page, then navigate away — verify no console errors
- [ ] Navigate rapidly between multiple app detail pages via related apps — verify no stale data or errors
- [ ] Navigate to a developer page, then navigate away — verify no console errors
- [ ] Switch language while on app detail page, then navigate away — verify no console errors
- [ ] Use browser back/forward buttons on app detail and developer pages — verify no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced component lifecycle management and subscription cleanup to ensure reliable operation during component transitions and prevent potential memory-related issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->