### PR TITLE
Fix RTL/LTR direction not updating on language switch

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -105,45 +105,24 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   ngOnInit() {
     console.log('🚀 AppComponent ngOnInit - listening to router events');
 
-    // Subscribe to router events
+    // Subscribe to language changes from the single source of truth (LanguageService)
+    // This replaces the previous competing onLangChange + NavigationEnd language handlers
+    this.languageService.currentLang$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((lang) => {
+        this.currentLang = lang as 'en' | 'ar';
+        this.isRtl = lang === 'ar';
+        this.updateMetaTags();
+      });
+
+    // Listen for route changes to update chrome visibility only (NOT language)
+    // Language is handled exclusively by LanguageService
     this.router.events.pipe(
-      filter(event => event instanceof NavigationEnd)
-    ).subscribe((event: any) => {
-      console.log('🔀 NavigationEnd:', event.url, 'Matched route config:', this.getCurrentRouteParams());
-    });
-
-    this.updateMetaTags();
-    this.translate.onLangChange.subscribe(() => {
-      this.updateMetaTags();
-    });
-
-    // Language service will handle language detection and RTL/LTR settings
-    // Just update the currentLang property when language changes
-    this.translate.onLangChange.subscribe((event) => {
-      this.currentLang = event.lang as "en" | "ar";
-      this.isRtl = this.currentLang === 'ar';
-      if (isPlatformBrowser(this.platformId)) {
-        document.documentElement.dir = this.isRtl ? 'rtl' : 'ltr';
-      }
-    });
-
-    // Also listen for route changes to update language and chrome visibility
-    this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(() => {
-      // Check if current route wants to hide header/footer
+      filter(event => event instanceof NavigationEnd),
+      takeUntil(this.destroy$)
+    ).subscribe(() => {
       this.hideChrome = !!this.route.snapshot.firstChild?.data?.['hideChrome'];
       this.hideFooter = !!this.route.snapshot.firstChild?.data?.['hideFooter'];
-
-      const lang = this.route.snapshot.firstChild?.paramMap.get('lang') || this.translate.getDefaultLang();
-      if (lang !== this.currentLang) {
-        // Wait for translations to load before updating state
-        this.translate.use(lang).subscribe(() => {
-          this.currentLang = lang as "en" | "ar";
-          this.isRtl = this.currentLang === 'ar';
-          if (isPlatformBrowser(this.platformId)) {
-            document.documentElement.dir = this.isRtl ? 'rtl' : 'ltr';
-          }
-        });
-      }
     });
 
     // Start preloading app images in background (non-blocking)
@@ -174,9 +153,6 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit() {
-    // Language service will handle URL changes
-    this.languageService.setLanguageFromUrl();
-
     // Initialize performance monitoring
     setTimeout(() => {
       this.performanceService.measurePerformance();
@@ -189,7 +165,8 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
     // Track route changes for analytics (when analytics is ready)
     this.router.events.pipe(
-      filter(event => event instanceof NavigationEnd)
+      filter(event => event instanceof NavigationEnd),
+      takeUntil(this.destroy$)
     ).subscribe((event: NavigationEnd) => {
       // Track page view with deferred analytics
       this.deferredAnalytics.trackPageView(event.urlAfterRedirects);
@@ -197,10 +174,8 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   toggleLanguage() {
-    const newLang = this.isRtl ? "en" : "ar";
+    const newLang = this.currentLang === 'ar' ? 'en' : 'ar';
     this.languageService.changeLanguage(newLang);
-    this.currentLang = newLang as "en" | "ar";
-    this.isRtl = newLang === "ar";
   }
 
   toggleMobileMenu() {

--- a/src/app/services/language.service.ts
+++ b/src/app/services/language.service.ts
@@ -2,7 +2,7 @@ import { Injectable, PLATFORM_ID, Inject } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { ActivatedRoute, ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { filter } from 'rxjs';
+import { BehaviorSubject, Observable, filter } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -10,6 +10,10 @@ import { filter } from 'rxjs';
 export class LanguageService {
   private supportedLanguages = ['en', 'ar'];
   private defaultLanguage = 'ar';
+  private urlSubscriptionActive = false;
+
+  private langSubject: BehaviorSubject<string>;
+  public readonly currentLang$: Observable<string>;
 
   constructor(
     @Inject(PLATFORM_ID) private readonly platformId: Object,
@@ -20,10 +24,18 @@ export class LanguageService {
     // Translations are initialized via APP_INITIALIZER in main.ts
     // Just get the current language and set up URL change listener
     this.defaultLanguage = this.translate.currentLang || this.translate.getDefaultLang() || 'ar';
+    this.langSubject = new BehaviorSubject<string>(this.defaultLanguage);
+    this.currentLang$ = this.langSubject.asObservable();
     this.setLanguageFromUrl();
   }
 
   setLanguageFromUrl() {
+    // Prevent duplicate subscriptions (guard for safety — called once from constructor)
+    if (this.urlSubscriptionActive) {
+      return;
+    }
+    this.urlSubscriptionActive = true;
+
     // use this to set the language from the url when the page is loaded using the router events
     this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(event => {
       const currentUrl = (event as NavigationEnd).url;
@@ -34,14 +46,14 @@ export class LanguageService {
       const lang = pathSegments[0]; // First non-empty segment should be the language
 
       if (this.supportedLanguages.includes(lang)) {
-        this.translate.setDefaultLang(lang);
-        // Wait for translations to load before updating DOM
-        this.translate.use(lang).subscribe(() => {
-          if (isPlatformBrowser(this.platformId)) {
-            document.documentElement.lang = lang;
-            document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr'; // Adjust direction
-          }
-        });
+        // Only update if language actually changed — prevents race conditions
+        if (lang !== this.langSubject.getValue()) {
+          // Wait for translations to load before updating DOM
+          this.translate.use(lang).subscribe({
+            next: () => this.applyLanguage(lang),
+            error: () => this.applyLanguage(lang)
+          });
+        }
       } else {
         // Redirect to default language (preserve any additional path segments)
         const remainingPath = pathSegments.slice(1).join('/');
@@ -49,41 +61,37 @@ export class LanguageService {
         this.router.navigateByUrl(targetUrl);
       }
     });
-    // this.route.params.subscribe(params => {
-    //   console.log("params", params);
-    //   const lang = params['lang'];
-    //   console.log("lang", lang);
-      
-    //   if (this.supportedLanguages.includes(lang)) {
-    //     this.translate.setDefaultLang(lang);
-    //     this.translate.use(lang);
-    //     document.documentElement.lang = lang;
-    //     document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr'; // Adjust direction
-    //   } else {
-    //    // this.router.navigate([this.defaultLanguage]); // Redirect to default if language is invalid
-    //   }
-    // });
   }
 
   changeLanguage(lang: string) {
     if (this.supportedLanguages.includes(lang)) {
       // Wait for translations to load before navigating
-      this.translate.use(lang).subscribe(() => {
-        if (isPlatformBrowser(this.platformId)) {
-          document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
-          document.documentElement.lang = lang;
-        }
-
-        // Preserve path segments when changing language
-        const currentUrl = this.router.url;
-        const urlPath = currentUrl.split('?')[0];
-        const pathSegments = urlPath.split('/').filter(segment => segment);
-        const remainingPath = pathSegments.slice(1).join('/'); // Remove existing language, keep rest
-        const targetUrl = `/${lang}/${remainingPath}`;
-
-        this.router.navigateByUrl(targetUrl);
+      this.translate.use(lang).subscribe({
+        next: () => this.applyLanguageAndNavigate(lang),
+        error: () => this.applyLanguageAndNavigate(lang)
       });
     }
+  }
+
+  /** Apply language then navigate to the same page with the new language prefix */
+  private applyLanguageAndNavigate(lang: string) {
+    this.applyLanguage(lang);
+    const currentUrl = this.router.url;
+    const urlPath = currentUrl.split('?')[0];
+    const pathSegments = urlPath.split('/').filter(segment => segment);
+    const remainingPath = pathSegments.slice(1).join('/');
+    const targetUrl = `/${lang}/${remainingPath}`;
+    this.router.navigateByUrl(targetUrl);
+  }
+
+  /** Single place that applies language to DOM and notifies subscribers */
+  private applyLanguage(lang: string) {
+    this.translate.setDefaultLang(lang);
+    if (isPlatformBrowser(this.platformId)) {
+      document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
+      document.documentElement.lang = lang;
+    }
+    this.langSubject.next(lang);
   }
 
   getCurrentRouteParams(): any {


### PR DESCRIPTION
## Summary
- **Root cause**: Three competing language handlers in `AppComponent` raced to set `document.documentElement.dir`, causing intermittent RTL/LTR failures on language switch
- **Fix**: Centralized all language state into `LanguageService` via a `BehaviorSubject` single source of truth; `AppComponent` now subscribes to a single `currentLang$` observable instead of 3 competing handlers
- **Net result**: -80 lines removed, +63 lines added (17 lines net reduction)

## Test plan
- [ ] Switch language AR → EN: page direction changes to LTR, all text renders left-to-right
- [ ] Switch language EN → AR: page direction changes to RTL, all text renders right-to-left
- [ ] Navigate to `/ar/kids` then switch to EN: URL becomes `/en/kids`, direction updates correctly
- [ ] Rapid language toggle (click 5+ times quickly): final state is consistent with last click
- [ ] Direct URL entry (`/en` or `/ar`): correct direction on first load
- [ ] Invalid URL (no language prefix): redirects to default language with correct direction
- [ ] `ng build --configuration=development` passes with 0 errors

Closes #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Centralized language switching for enhanced reliability and consistency
  * Language changes now properly preserve your current page location and update site metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->