### PR TITLE
Fix OG image for app share previews to use branded card instead of raw icon

### DIFF
--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -115,13 +115,18 @@ const generateOGTags = (route: RouteInfo, data: any): OGTags => {
       ? (data.short_description_ar || data.description_ar)
       : (data.short_description_en || data.description_en);
 
-    const hasAppIcon = !!data.application_icon;
+    // Use the backend OG image endpoint which generates a branded 1200x630 share card
+    // with app icon, name, description, and Itqan branding
+    const ogImage = data.slug
+      ? `${API_BASE}/apps/${data.slug}/og-image/?lang=${route.lang}`
+      : DEFAULT_IMAGE;
+
     return {
       title: title || 'Quran App',
       description: description || '',
-      image: data.application_icon || DEFAULT_IMAGE,
-      imageWidth: hasAppIcon ? 512 : 1200,
-      imageHeight: hasAppIcon ? 512 : 630,
+      image: ogImage,
+      imageWidth: 1200,
+      imageHeight: 630,
       url: `${BASE_URL}/${route.lang}/app/${data.slug}`,
       type: 'website',
       locale: route.lang === 'ar' ? 'ar_SA' : 'en_US',


### PR DESCRIPTION
#236
When sharing an app page link on WhatsApp, Telegram, Twitter, or LinkedIn, the preview card showed the app's raw square icon (512x512) instead of the branded share card generated by the backend.

The Cloudflare Pages Function that injects OG tags for social media crawlers was pointing og:image at the application_icon URL directly. Updated it to use the backend's /api/apps/{slug}/og-image/?lang= endpoint, which generates a proper 1200x630 branded card with app icon, name, description, and Itqan branding.

Changes:
- Updated `generateOGTags()` in functions/[[path]].ts for app pages
- og:image now points to backend OG image generation endpoint
- Image dimensions consistently set to 1200x630 (standard OG size)
- Falls back to default site thumbnail if slug is unavailable
