### PR TITLE
Hide backend URL from frontend environment config

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -142,7 +142,10 @@
               "buildTarget": "demo:build:production"
             }
           },
-          "defaultConfiguration": "development"
+          "defaultConfiguration": "development",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          }
         }
       },
       "prefix": "app",

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,8 @@
+{
+  "/api": {
+    "target": "https://qad-backend-api-production.up.railway.app",
+    "secure": true,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}

--- a/src/app/pages/app-detail/app-detail.component.ts
+++ b/src/app/pages/app-detail/app-detail.component.ts
@@ -606,7 +606,7 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
       property: "og:description",
       content: appDescription || "",
     });
-    const ogImageUrl = `${environment.apiUrl}/apps/${this.app.slug}/og-image/?lang=${this.currentLang}`;
+    const ogImageUrl = `${environment.appUrl}/api/apps/${this.app.slug}/og-image/?lang=${this.currentLang}`;
     this.metaService.updateTag({
       property: "og:image",
       content: ogImageUrl,

--- a/src/assets/_redirects
+++ b/src/assets/_redirects
@@ -1,4 +1,8 @@
 # Cloudflare Pages Redirects Configuration
+
+# Proxy API requests to backend (hides internal service URL)
+/api/* https://qad-backend-api-production.up.railway.app/api/:splat 200
+
 # SPA routing: Serve index.html for all routes EXCEPT static assets
 
 # Exclude static assets from redirect

--- a/src/environments/environment.develop.ts
+++ b/src/environments/environment.develop.ts
@@ -4,7 +4,7 @@ export const environment = {
   development: true,
   appName: 'Quran Apps Directory (Dev)',
   appUrl: 'https://quran-apps-directory-frontend.pages.dev',
-  apiUrl: 'https://qad-backend-api-production.up.railway.app/api',
+  apiUrl: '/api',
   version: '1.0.0-dev',
   analytics: {
     enabled: false,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -4,7 +4,7 @@ export const environment = {
   development: false,
   appName: 'Quran Apps Directory',
   appUrl: 'https://quran-apps.itqan.dev',
-  apiUrl: 'https://qad-backend-api-production.up.railway.app/api',
+  apiUrl: '/api',
   version: '1.0.0',
   analytics: {
     enabled: true,
@@ -19,7 +19,7 @@ export const environment = {
   sentry: {
     enabled: true,
     dsn: 'https://10ae32f7f36add568917f16d53562358@o4510669335232512.ingest.de.sentry.io/4510669357842512',
-    tunnel: 'https://qad-backend-api-production.up.railway.app/api/sentry-tunnel/',
+    tunnel: '/api/sentry-tunnel/',
     environment: 'production',
     tracesSampleRate: 0.1,
     replaysSessionSampleRate: 0.1,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -4,7 +4,7 @@ export const environment = {
   development: false,
   appName: 'Quran Apps Directory (Staging)',
   appUrl: 'https://staging.quran-apps-directory-frontend.pages.dev',
-  apiUrl: 'https://qad-backend-api-staging.up.railway.app/api',
+  apiUrl: '/api',
   version: '1.0.0-staging',
   analytics: {
     enabled: false,
@@ -19,7 +19,7 @@ export const environment = {
   sentry: {
     enabled: true,
     dsn: 'https://10ae32f7f36add568917f16d53562358@o4510669335232512.ingest.de.sentry.io/4510669357842512',
-    tunnel: 'https://qad-backend-api-staging.up.railway.app/api/sentry-tunnel/',
+    tunnel: '/api/sentry-tunnel/',
     environment: 'staging',
     tracesSampleRate: 1.0,
     replaysSessionSampleRate: 0.1,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@ export const environment = {
   development: true,
   appName: 'Quran Apps Directory (Dev)',
   appUrl: 'http://localhost:8000',
-  apiUrl: 'https://qad-backend-api-production.up.railway.app/api',
+  apiUrl: '/api',
   apiVersion: 'v1',
   version: '1.0.1-dev',
   analytics: {

--- a/src/ngsw-config.json
+++ b/src/ngsw-config.json
@@ -44,12 +44,8 @@
     {
       "name": "api-apps-categories",
       "urls": [
-        "https://qad-backend-api-production.up.railway.app/api/apps/**",
-        "https://qad-backend-api-production.up.railway.app/api/categories/**",
-        "https://qad-backend-api-staging.up.railway.app/api/apps/**",
-        "https://qad-backend-api-staging.up.railway.app/api/categories/**",
-        "https://qad-backend-api-develop.up.railway.app/api/apps/**",
-        "https://qad-backend-api-develop.up.railway.app/api/categories/**"
+        "/api/apps/**",
+        "/api/categories/**"
       ],
       "cacheConfig": {
         "maxSize": 200,
@@ -61,9 +57,7 @@
     {
       "name": "api-other",
       "urls": [
-        "https://qad-backend-api-production.up.railway.app/api/**",
-        "https://qad-backend-api-staging.up.railway.app/api/**",
-        "https://qad-backend-api-develop.up.railway.app/api/**"
+        "/api/**"
       ],
       "cacheConfig": {
         "maxSize": 100,


### PR DESCRIPTION
## Summary

Fixes #184

The frontend environment files were exposing the internal Railway backend service URLs (e.g., `https://qad-backend-api-production.up.railway.app/api`), which get shipped to the browser in the JavaScript bundle. This allows anyone to discover and directly call the backend, bypassing any frontend-level security measures.

### Changes

- **Environment files** (`environment.ts`, `environment.prod.ts`, `environment.staging.ts`, `environment.develop.ts`): Replaced absolute backend URLs with relative `/api` path
- **Cloudflare Pages proxy** (`_redirects`): Added proxy rule to forward `/api/*` requests to the backend, keeping the real URL server-side only
- **Angular dev proxy** (`proxy.conf.json`): Added development proxy configuration so `ng serve` forwards `/api` requests to the backend
- **Angular config** (`angular.json`): Configured dev server to use the proxy
- **Sentry tunnel URLs**: Updated to use relative paths instead of absolute Railway URLs
- **Service worker config** (`ngsw-config.json`): Updated API cache URLs to use relative paths
- **OG image URL** (`app-detail.component.ts`): Uses `appUrl` + relative path for absolute URLs needed by social media crawlers

### How it works

- **Production/Staging**: Cloudflare Pages `_redirects` proxies `/api/*` to the Railway backend with a `200` status (transparent proxy)
- **Development**: Angular CLI proxy (`proxy.conf.json`) forwards `/api` requests to the backend
- The real backend URL only exists in `_redirects` (server-side) and `proxy.conf.json` (dev-only, never deployed)

### Testing

- [x] Build succeeds with `npm run build`
- [ ] Verify API calls work through the Cloudflare proxy on staging
- [ ] Verify `ng serve` correctly proxies API requests locally