### PR TITLE
Use backend OG image endpoint for per-app share card previews

### DIFF
--- a/backend/apps/api/controllers.py
+++ b/backend/apps/api/controllers.py
@@ -282,10 +282,14 @@ def get_app_og_image(request, app_id: str):
         "updated_at": str(app_obj.updated_at),
     }
 
-    image_bytes = generate_og_image(app_data, lang=lang)
+    try:
+        image_bytes = generate_og_image(app_data, lang=lang)
+    except Exception:
+        from django.shortcuts import redirect
+        return redirect("https://quran-apps.itqan.dev/assets/images/Social-Media-Thumnail-2x.jpg")
 
     response = HttpResponse(image_bytes, content_type="image/png")
-    response["Cache-Control"] = "public, max-age=86400"  # Cache for 24 hours
+    response["Cache-Control"] = "public, max-age=86400"
     return response
 
 

--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -115,13 +115,16 @@ const generateOGTags = (route: RouteInfo, data: any): OGTags => {
       ? (data.short_description_ar || data.description_ar)
       : (data.short_description_en || data.description_en);
 
-    const hasAppIcon = !!data.application_icon;
+    const ogImage = data.slug
+      ? `${API_BASE}/apps/${data.slug}/og-image/?lang=${route.lang}`
+      : DEFAULT_IMAGE;
+
     return {
       title: title || 'Quran App',
       description: description || '',
-      image: data.application_icon || DEFAULT_IMAGE,
-      imageWidth: hasAppIcon ? 512 : 1200,
-      imageHeight: hasAppIcon ? 512 : 630,
+      image: ogImage,
+      imageWidth: 1200,
+      imageHeight: 630,
       url: `${BASE_URL}/${route.lang}/app/${data.slug}`,
       type: 'website',
       locale: route.lang === 'ar' ? 'ar_SA' : 'en_US',

--- a/src/app/pages/app-detail/app-detail.component.ts
+++ b/src/app/pages/app-detail/app-detail.component.ts
@@ -639,6 +639,18 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
       content: ogImageUrl,
     });
     this.metaService.updateTag({
+      property: "og:image:width",
+      content: "1200",
+    });
+    this.metaService.updateTag({
+      property: "og:image:height",
+      content: "630",
+    });
+    this.metaService.updateTag({
+      property: "og:image:alt",
+      content: appName,
+    });
+    this.metaService.updateTag({
       property: "og:url",
       content: `https://quran-apps.itqan.dev/${this.currentLang}/app/${this.app.slug}_${this.app.id}`,
     });


### PR DESCRIPTION
## Summary

Closes #236

When sharing an app page link on WhatsApp, Telegram, Twitter, or LinkedIn, the preview card showed the app's raw square icon (512x512) instead of a branded share card. This PR fixes the Cloudflare Pages Function to use the backend's OG image generation endpoint, which produces a proper 1200x630 card with app icon, name, description, and Itqan branding.

### Changes

- **`functions/[[path]].ts`** — Point `og:image` to the backend's `/api/apps/{slug}/og-image/?lang=` endpoint instead of the raw `application_icon` URL. Image dimensions consistently set to 1200x630 (standard OG size). Falls back to the default site thumbnail if slug is unavailable.
- **`src/app/pages/app-detail/app-detail.component.ts`** — Add `og:image:width`, `og:image:height`, and `og:image:alt` meta tags for proper rendering in social platforms.
- **`backend/apps/api/controllers.py`** — Add error handling around `generate_og_image()` with fallback redirect to the generic site thumbnail if image generation fails.

### How it works

1. Social media crawlers (WhatsApp, Telegram, Twitter, etc.) hit the Cloudflare Pages Function
2. The function detects the crawler and fetches app data from the API
3. For app pages, `og:image` now points to `{API_BASE}/apps/{slug}/og-image/?lang={lang}`
4. The backend endpoint generates a branded 1200x630 PNG card using Pillow with the app's icon, name, short description, and Itqan branding
5. The generated image is cached for 24 hours

### Testing

- [ ] Share an app page URL on WhatsApp and verify the branded card appears
- [ ] Share on Telegram, Twitter, and LinkedIn
- [ ] Test both Arabic and English variants (`?lang=ar` and `?lang=en`)
- [ ] Verify fallback works when app data is unavailable (generic site thumbnail shown)
- [ ] Verify RTL layout renders correctly for Arabic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for app image generation to prevent failures and provide reliable fallback behavior

* **Improvements**
  * Standardized Open Graph image dimensions (1200x630) for app pages shared on social media
  * Enhanced preview metadata with image width, height, and descriptive alt text for better social sharing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->