### PR TITLE
chore: add automation workflows

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,9 @@
+name: Post-Deploy Health Check
+on:
+  push:
+    branches: [main, staging]
+
+jobs:
+  check:
+    uses: Itqan-community/.github/.github/workflows/health-check.yml@main
+    secrets: inherit

--- a/.github/workflows/hub-compliance.yml
+++ b/.github/workflows/hub-compliance.yml
@@ -1,0 +1,9 @@
+name: Org Compliance Check
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main, staging]
+
+jobs:
+  check:
+    uses: Itqan-community/.github/.github/workflows/hub-compliance.yml@main


### PR DESCRIPTION
Adds centralized automation workflow stubs from `Itqan-community/.github`.

## What's included
- `slack-notifications.yml` — PR/issue/push events → Slack
- `branch-naming.yml` — enforces feature/\*, hotfix/\*, community/\*
- `community-detection.yml` — labels and notifies external contributors
- `stale.yml` — 14d stale label, 21d auto-close
- `release-drafter.yml` — auto-drafts release notes grouped by feat/fix/chore
- `notion-sync.yml` — GitHub issues → Notion tasks (Phase 2, needs NOTION_API_KEY secret)
- `hub-compliance.yml` — verifies all required stubs present on every PR (org compliance gate)
- `release-drafter.yml` config — release note template

All workflow logic lives in [`Itqan-community/.github`](https://github.com/Itqan-community/.github). These files are thin stubs that call into the central workflows.

## Secrets required
`SLACK_WEBHOOK_ENGINEERING_ALERTS`, `SLACK_WEBHOOK_RELEASES`, `SLACK_WEBHOOK_COMMUNITY_UPDATES`, `SLACK_WEBHOOK_INCIDENTS` — set at repo level.
`NOTION_API_KEY`, `NOTION_TASKS_DB_ID` — set these before merging if you want Notion sync active.
`HEALTH_CHECK_URL` — optional. Set to your Railway service URL (e.g. `https://your-app.railway.app/health`) to enable post-deploy health checks.

## GitHub Environments
`staging` and `prod` environments have been created on this repo. Override any secret per-environment when values differ.