### PR TITLE
Fix App Submission Form Failures

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,55 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: '🚀 Features'
+    labels:
+      - feature
+      - feat
+    exclude-labels:
+      - community
+  - title: '🐛 Bug Fixes'
+    labels:
+      - fix
+      - bugfix
+      - bug
+    exclude-labels:
+      - community
+  - title: '🔧 Maintenance'
+    labels:
+      - chore
+      - maintenance
+      - deps
+    exclude-labels:
+      - community
+  - title: '🌍 Community Contributions'
+    labels:
+      - community
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - major
+      - breaking-change
+  minor:
+    labels:
+      - minor
+      - feature
+      - feat
+  patch:
+    labels:
+      - patch
+      - fix
+      - bugfix
+      - chore
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: $PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -1,0 +1,9 @@
+name: Branch Naming Check
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches: [main, staging]
+
+jobs:
+  check:
+    uses: Itqan-community/.github/.github/workflows/branch-naming.yml@main

--- a/.github/workflows/community-detection.yml
+++ b/.github/workflows/community-detection.yml
@@ -1,0 +1,9 @@
+name: Community Contributor Detection
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  detect:
+    uses: Itqan-community/.github/.github/workflows/community-detection.yml@main
+    secrets: inherit

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,9 @@
+name: Post-Deploy Health Check
+on:
+  push:
+    branches: [main, staging]
+
+jobs:
+  check:
+    uses: Itqan-community/.github/.github/workflows/health-check.yml@main
+    secrets: inherit

--- a/.github/workflows/hub-compliance.yml
+++ b/.github/workflows/hub-compliance.yml
@@ -1,0 +1,9 @@
+name: Org Compliance Check
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main, staging]
+
+jobs:
+  check:
+    uses: Itqan-community/.github/.github/workflows/hub-compliance.yml@main

--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -1,0 +1,11 @@
+name: Notion Sync
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [closed]
+
+jobs:
+  sync:
+    uses: Itqan-community/.github/.github/workflows/notion-sync.yml@main
+    secrets: inherit

--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -1,9 +1,11 @@
 name: Notion Sync
 on:
   issues:
-    types: [opened]
+    types: [opened, closed]
   pull_request:
     types: [closed]
+  issue_comment:
+    types: [created]
 
 jobs:
   sync:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,11 @@
+name: Release Drafter
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  draft:
+    uses: Itqan-community/.github/.github/workflows/release-drafter.yml@main
+    secrets: inherit

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -1,0 +1,13 @@
+name: Slack Notifications
+on:
+  pull_request:
+    types: [opened, closed]
+  issues:
+    types: [opened, labeled]
+  push:
+    branches: [main, staging]
+
+jobs:
+  notify:
+    uses: Itqan-community/.github/.github/workflows/slack-notifications.yml@main
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,9 @@
+name: Stale PRs
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    uses: Itqan-community/.github/.github/workflows/stale.yml@main

--- a/.smoke-test-tmp
+++ b/.smoke-test-tmp
@@ -1,0 +1,1 @@
+smoke test 3

--- a/.smoke-test-tmp
+++ b/.smoke-test-tmp
@@ -1,1 +1,0 @@
-smoke test 3

--- a/backend/submissions/api/controllers.py
+++ b/backend/submissions/api/controllers.py
@@ -12,6 +12,7 @@ import logging
 from submissions.models import AppSubmission, SubmissionStatus
 from submissions.services.submission_service import SubmissionService
 from submissions.services.storage_service import get_storage_service, StorageError
+from submissions.validators import is_valid_url
 from .schemas import (
     SubmissionCreateSchema,
     SubmissionResponseSchema,
@@ -48,17 +49,17 @@ def create_submission(request, data: SubmissionCreateSchema):
     Creates a new submission and sends a confirmation email to the submitter.
     Returns a tracking ID that can be used to check the submission status.
     """
-    # Validate at least one store link
-    if not (data.google_play_link or data.app_store_link):
-        raise HttpError(400, "At least one store link (Google Play or App Store) is required")
+    # Validate app name
+    if not data.app_name_en or not data.app_name_en.strip():
+        raise HttpError(400, "Please enter an app name")
 
-    # Validate content confirmation
-    if not data.content_confirmation:
-        raise HttpError(400, "You must confirm that the content doesn't violate guidelines")
-
-    # Validate categories
-    if not data.categories:
-        raise HttpError(400, "Please select at least one category")
+    # Validate at least one well-formed store link
+    store_links = [data.google_play_link, data.app_store_link, data.app_gallery_link]
+    if not any(is_valid_url(link) for link in store_links):
+        raise HttpError(
+            400,
+            "Please enter a valid Store Link (e.g. https://play.google.com/... or https://apps.apple.com/...)"
+        )
 
     try:
         service = SubmissionService()

--- a/backend/submissions/api/schemas.py
+++ b/backend/submissions/api/schemas.py
@@ -19,31 +19,31 @@ class CategorySchema(Schema):
 class SubmissionCreateSchema(Schema):
     """Schema for creating a new submission."""
     # Contact Information
-    submitter_name: str
+    submitter_name: Optional[str] = ''
     submitter_email: str
     submitter_phone: Optional[str] = ''
     submitter_organization: Optional[str] = ''
     is_developer: bool = False
 
-    # App Details (Bilingual)
+    # App Details (Bilingual) - only app_name_en is required
     app_name_en: str
-    app_name_ar: str
-    short_description_en: str
-    short_description_ar: str
+    app_name_ar: Optional[str] = ''
+    short_description_en: Optional[str] = ''
+    short_description_ar: Optional[str] = ''
     description_en: Optional[str] = ''
     description_ar: Optional[str] = ''
 
-    # Store Links (at least one required)
+    # Store Links (at least one valid link required)
     google_play_link: Optional[str] = ''
     app_store_link: Optional[str] = ''
     app_gallery_link: Optional[str] = ''
     website_link: Optional[str] = ''
 
-    # Categories (list of category IDs)
-    categories: List[int]
+    # Categories (list of category IDs, optional)
+    categories: Optional[List[int]] = []
 
     # Developer Info
-    developer_name_en: str
+    developer_name_en: Optional[str] = ''
     developer_name_ar: Optional[str] = ''
     developer_website: Optional[str] = ''
     developer_email: Optional[str] = ''

--- a/backend/submissions/services/submission_service.py
+++ b/backend/submissions/services/submission_service.py
@@ -269,6 +269,20 @@ class SubmissionService:
             logger.error(f"Failed to upload images for {submission.tracking_id}: {e}")
             raise ValueError(f"Failed to upload images to R2: {str(e)}")
 
+        # The public submission form no longer collects an icon/main images,
+        # so a submission can reach here without them. Block approval with a
+        # clear message rather than silently publishing a broken listing.
+        if not r2_urls.get('app_icon_url'):
+            raise ValueError(
+                f"Cannot approve {submission.tracking_id}: no app icon on file. "
+                f"Add an icon via Django Admin (AppSubmission.app_icon_url) before approving."
+            )
+        if not r2_urls.get('main_image_en') or not r2_urls.get('main_image_ar'):
+            raise ValueError(
+                f"Cannot approve {submission.tracking_id}: missing main image (en/ar). "
+                f"Add via Django Admin before approving."
+            )
+
         # Create the App with R2 image URLs and default rating of 2.5
         app = App.objects.create(
             name_en=submission.app_name_en,

--- a/backend/submissions/tests/test_create_submission_api.py
+++ b/backend/submissions/tests/test_create_submission_api.py
@@ -1,0 +1,79 @@
+"""
+Tests for POST /api/submissions/ validation behavior.
+
+Regression coverage for the simplified submission form: only app_name_en,
+submitter_email, and a well-formed store link should be required.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+MINIMAL_VALID_PAYLOAD = {
+    "submitter_email": "dev@example.com",
+    "app_name_en": "Test Quran App",
+    "google_play_link": "https://play.google.com/store/apps/details?id=com.example",
+}
+
+
+class CreateSubmissionApiTest(TestCase):
+    def setUp(self):
+        # Avoid sending real emails during tests.
+        patcher = patch("submissions.services.submission_service.get_email_service")
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_minimal_payload_with_valid_store_link_succeeds(self):
+        response = self.client.post(
+            "/api/submissions/",
+            data=MINIMAL_VALID_PAYLOAD,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+        self.assertIn("tracking_id", response.json())
+
+    def test_missing_app_name_is_rejected(self):
+        payload = {**MINIMAL_VALID_PAYLOAD, "app_name_en": ""}
+        response = self.client.post(
+            "/api/submissions/", data=payload, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_malformed_store_link_is_rejected(self):
+        payload = {**MINIMAL_VALID_PAYLOAD, "google_play_link": "not-a-url"}
+        response = self.client.post(
+            "/api/submissions/", data=payload, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn("valid Store Link", response.json().get("detail", ""))
+
+    def test_missing_store_link_is_rejected(self):
+        payload = {**MINIMAL_VALID_PAYLOAD, "google_play_link": ""}
+        response = self.client.post(
+            "/api/submissions/", data=payload, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_app_gallery_link_alone_is_accepted(self):
+        payload = {
+            **MINIMAL_VALID_PAYLOAD,
+            "google_play_link": "",
+            "app_gallery_link": "https://appgallery.huawei.com/app/C123456",
+        }
+        response = self.client.post(
+            "/api/submissions/", data=payload, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+
+    def test_content_confirmation_no_longer_required(self):
+        # Previously the API hard-required content_confirmation=True.
+        response = self.client.post(
+            "/api/submissions/", data=MINIMAL_VALID_PAYLOAD, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+
+    def test_categories_no_longer_required(self):
+        # Previously the API hard-required at least one category.
+        response = self.client.post(
+            "/api/submissions/", data=MINIMAL_VALID_PAYLOAD, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 201, response.content)

--- a/backend/submissions/tests/test_submission_service.py
+++ b/backend/submissions/tests/test_submission_service.py
@@ -1,0 +1,90 @@
+"""
+Tests for SubmissionService.approve_submission's icon/main-image guard.
+
+Regression coverage: once icon collection is no longer required on the
+public form, approving a submission with no icon/main images must fail
+loudly instead of silently publishing a broken listing (empty
+application_icon on the live App).
+"""
+from unittest.mock import patch, MagicMock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from submissions.models import AppSubmission
+from submissions.services.submission_service import SubmissionService
+
+User = get_user_model()
+
+
+def _make_submission(**overrides):
+    defaults = dict(
+        submitter_name="Jane Dev",
+        submitter_email="jane@example.com",
+        app_name_en="Test App",
+        app_name_ar="تطبيق اختبار",
+        short_description_en="Short desc",
+        short_description_ar="وصف قصير",
+        google_play_link="https://play.google.com/store/apps/details?id=com.example",
+        developer_name_en="Jane Studio",
+    )
+    defaults.update(overrides)
+    return AppSubmission.objects.create(**defaults)
+
+
+class ApproveSubmissionIconGuardTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="admin", password="pw")
+
+        email_patcher = patch("submissions.services.submission_service.get_email_service")
+        self.addCleanup(email_patcher.stop)
+        email_patcher.start()
+
+        storage_patcher = patch("submissions.services.submission_service.get_storage_service")
+        self.mock_get_storage = storage_patcher.start()
+        self.addCleanup(storage_patcher.stop)
+
+        self.mock_storage = MagicMock()
+        self.mock_storage.is_configured.return_value = True
+        self.mock_storage.get_config_status.return_value = {"is_configured": True}
+        self.mock_get_storage.return_value = self.mock_storage
+
+        self.service = SubmissionService()
+
+    def test_approval_blocked_when_no_icon(self):
+        submission = _make_submission(app_icon_url="", main_image_en="", main_image_ar="")
+
+        with self.assertRaises(ValueError) as ctx:
+            self.service.approve_submission(submission, self.user)
+
+        self.assertIn("icon", str(ctx.exception).lower())
+        submission.refresh_from_db()
+        self.assertNotEqual(submission.status, "approved")
+        self.assertIsNone(submission.created_app)
+
+    def test_approval_blocked_when_no_main_images(self):
+        submission = _make_submission(
+            app_icon_url="https://example.com/icon.png",
+            main_image_en="",
+            main_image_ar="",
+        )
+        self.mock_storage.upload_from_url.return_value = "https://r2.example.com/icon.png"
+
+        with self.assertRaises(ValueError) as ctx:
+            self.service.approve_submission(submission, self.user)
+
+        self.assertIn("main image", str(ctx.exception).lower())
+
+    def test_approval_succeeds_when_icon_and_main_images_present(self):
+        submission = _make_submission(
+            app_icon_url="https://example.com/icon.png",
+            main_image_en="https://example.com/main_en.png",
+            main_image_ar="https://example.com/main_ar.png",
+        )
+        self.mock_storage.upload_from_url.side_effect = lambda url, *a, **k: url.replace(
+            "example.com", "r2.example.com"
+        )
+
+        app = self.service.approve_submission(submission, self.user)
+
+        self.assertEqual(app.application_icon.name, "https://r2.example.com/icon.png")

--- a/backend/submissions/tests/test_validators.py
+++ b/backend/submissions/tests/test_validators.py
@@ -1,0 +1,35 @@
+"""
+Tests for submission store-link URL validation.
+
+Regression coverage for the "at least one store link" check in
+create_submission accepting any non-empty string instead of a real URL.
+"""
+from django.test import TestCase
+
+from submissions.validators import is_valid_url
+
+
+class IsValidUrlTest(TestCase):
+    def test_accepts_https_url(self):
+        self.assertTrue(is_valid_url("https://play.google.com/store/apps/details?id=com.example"))
+
+    def test_accepts_http_url(self):
+        self.assertTrue(is_valid_url("http://apps.apple.com/app/id123456"))
+
+    def test_rejects_plain_string(self):
+        self.assertFalse(is_valid_url("not-a-url"))
+
+    def test_rejects_empty_string(self):
+        self.assertFalse(is_valid_url(""))
+
+    def test_rejects_none(self):
+        self.assertFalse(is_valid_url(None))
+
+    def test_rejects_scheme_without_host(self):
+        self.assertFalse(is_valid_url("https://"))
+
+    def test_rejects_non_http_scheme(self):
+        self.assertFalse(is_valid_url("ftp://example.com/app"))
+
+    def test_rejects_javascript_scheme(self):
+        self.assertFalse(is_valid_url("javascript:alert(1)"))

--- a/backend/submissions/validators.py
+++ b/backend/submissions/validators.py
@@ -1,0 +1,22 @@
+"""
+Validators for app submission data.
+"""
+from urllib.parse import urlparse
+
+
+def is_valid_url(url) -> bool:
+    """
+    Check whether a string is a well-formed http(s) URL.
+
+    Used to validate store links (Google Play / App Store / AppGallery)
+    submitted through the app submission form.
+    """
+    if not url or not isinstance(url, str):
+        return False
+
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+
+    return parsed.scheme in ('http', 'https') and bool(parsed.netloc)

--- a/src/app/pages/app-list/app-list.component.html
+++ b/src/app/pages/app-list/app-list.component.html
@@ -504,6 +504,16 @@
       }
     </div>
 
+    <!-- Loading More Indicator for Infinite Scroll -->
+    @if (isLoadingMore && filteredApps.length > 0 && !isSmartSearching) {
+      <div style="text-align: center; margin: 24px 0">
+        <nz-spin nzSimple></nz-spin>
+        <span style="margin-left: 12px; color: var(--nz-text-color-secondary);">
+          {{ currentLang === "ar" ? "جارِ تحميل المزيد..." : "Loading more..." }}
+        </span>
+      </div>
+    }
+
     <!-- Load More Button for Smart Search -->
     @if (smartSearchHasMore && !isSmartSearching) {
       <div

--- a/src/app/pages/app-list/app-list.component.ts
+++ b/src/app/pages/app-list/app-list.component.ts
@@ -81,6 +81,10 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
   ramadanMode = RAMADAN_MODE;
   // Track if initial data load has completed (to avoid showing "no apps" before data arrives)
   initialLoadComplete = false;
+  // Infinite scroll state
+  isLoadingMore = false;
+  hasMoreApps = true;
+  totalAppsCount = 0;
   error: string | null = null;
   isDragging = false;
   startX = 0;
@@ -294,22 +298,40 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @HostListener("window:scroll")
   onWindowScroll(): void {
-    if (
-      !isPlatformBrowser(this.platformId) ||
-      !this.navbarScrollService.isDesktopMode()
-    ) {
+    if (!isPlatformBrowser(this.platformId)) {
       return;
     }
 
-    const scrollY = window.scrollY;
-    const shouldBeCompact = scrollY > this.searchSectionTop - this.navbarHeight;
+    // Handle infinite scroll (only when not searching and not in smart search mode)
+    if (
+      !this.searchQuery.trim() &&
+      !this.isSmartSearching &&
+      this.hasMoreApps &&
+      !this.isLoadingMore &&
+      this.navbarScrollService.isDesktopMode()
+    ) {
+      const scrollTop = window.scrollY || document.documentElement.scrollTop;
+      const windowHeight = window.innerHeight;
+      const documentHeight = document.documentElement.scrollHeight;
 
-    if (shouldBeCompact !== this.isNavbarCompact) {
-      this.isNavbarCompact = shouldBeCompact;
-      this.navbarScrollService.setCompactMode(shouldBeCompact);
+      // Trigger load when user is within 800px of the bottom
+      if (scrollTop + windowHeight >= documentHeight - 800) {
+        this.loadMoreApps();
+      }
+    }
 
-      if (shouldBeCompact) {
-        this.updateNavbarSearchState();
+    // Handle navbar compact mode
+    if (this.navbarScrollService.isDesktopMode()) {
+      const scrollY = window.scrollY;
+      const shouldBeCompact = scrollY > this.searchSectionTop - this.navbarHeight;
+
+      if (shouldBeCompact !== this.isNavbarCompact) {
+        this.isNavbarCompact = shouldBeCompact;
+        this.navbarScrollService.setCompactMode(shouldBeCompact);
+
+        if (shouldBeCompact) {
+          this.updateNavbarSearchState();
+        }
       }
     }
   }
@@ -376,6 +398,8 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
         // Categories are already handled by the service and subject
         // Apps are already handled by the service and subject
         // Just ensure our local state is updated properly
+        // Capture total count for infinite scroll
+        this.totalAppsCount = appsResponse?.count || 0;
         if (!categories || categories.length === 0) {
           this.categories = [];
         }
@@ -421,12 +445,16 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
     this.suggestedQuery = null;
     const query = this.searchQuery.trim();
 
-    // If query is empty, just respect current category filter
+    // If query is empty, reset infinite scroll state and respect current category filter
     if (!query) {
       this.isSmartSearching = false;
       this.searchExecuted = false;
       this.isSmartSearchActive = false;
       this.smartSearchHasMore = false;
+      // Reset infinite scroll state for non-search views
+      this.isLoadingMore = false;
+      this.hasMoreApps = true;
+      this.totalAppsCount = 0;
       this.applyCategoryAndSearchFilters();
       return;
     }
@@ -500,6 +528,10 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
 
   onCategoryChipClick(slug: string): void {
     this.selectedCategory = slug;
+    // Reset infinite scroll state on category change
+    this.isLoadingMore = false;
+    this.hasMoreApps = true;
+    this.totalAppsCount = 0;
     if (slug === 'all') {
       this.isSmartSearchActive = false;
       this.filteredApps = this.apps;
@@ -514,6 +546,10 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
 
   filterByCategory(category: string) {
     this.selectedCategory = category.toLowerCase();
+    // Reset infinite scroll state when category changes
+    this.isLoadingMore = false;
+    this.hasMoreApps = true;
+    this.totalAppsCount = 0;
     if (this.isSmartSearchActive && this.searchQuery.trim()) {
       this.onSearch();
     } else {
@@ -525,6 +561,33 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
     this.error = null;
     this.isLoading = true;
     this.loadData();
+  }
+
+  /**
+   * Load the next page of apps via infinite scroll.
+   */
+  loadMoreApps(): void {
+    if (this.isLoadingMore || !this.hasMoreApps) return;
+    this.isLoadingMore = true;
+
+    this.apiService.loadNextPage()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (totalCount) => {
+          this.totalAppsCount = totalCount;
+          // Check if we've loaded all apps
+          if (this.apps.length >= totalCount) {
+            this.hasMoreApps = false;
+          }
+          this.isLoadingMore = false;
+          this.cdr.detectChanges();
+        },
+        error: () => {
+          this.isLoadingMore = false;
+          this.hasMoreApps = false;
+          this.cdr.detectChanges();
+        }
+      });
   }
 
   /**

--- a/src/app/pages/submit-app/submit-app.component.html
+++ b/src/app/pages/submit-app/submit-app.component.html
@@ -83,8 +83,9 @@
 
         <nz-form-item>
           <nz-form-label nzRequired>{{ 'submitApp.fields.appNameEn' | translate }}</nz-form-label>
-          <nz-form-control>
+          <nz-form-control [nzErrorTip]="'submitApp.validation.appNameRequired' | translate">
             <input nz-input
+              #appNameEnCtrl="ngModel"
               [(ngModel)]="formData.app_name_en"
               name="app_name_en"
               [placeholder]="'submitApp.placeholders.appNameEn' | translate"
@@ -93,19 +94,18 @@
         </nz-form-item>
 
         <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.fields.appNameAr' | translate }}</nz-form-label>
+          <nz-form-label>{{ 'submitApp.fields.appNameAr' | translate }}</nz-form-label>
           <nz-form-control>
             <input nz-input
               dir="rtl"
               [(ngModel)]="formData.app_name_ar"
               name="app_name_ar"
-              [placeholder]="'submitApp.placeholders.appNameAr' | translate"
-              required />
+              [placeholder]="'submitApp.placeholders.appNameAr' | translate" />
           </nz-form-control>
         </nz-form-item>
 
         <nz-form-item>
-          <nz-form-label nzRequired>
+          <nz-form-label>
             {{ 'submitApp.fields.shortDescEn' | translate }}
             <span class="char-count" [class.warning]="shortDescEnCount > 150">
               ({{ shortDescEnCount }}/150)
@@ -117,13 +117,12 @@
               [(ngModel)]="formData.short_description_en"
               name="short_description_en"
               [placeholder]="'submitApp.placeholders.shortDescEn' | translate"
-              maxlength="150"
-            required></textarea>
+              maxlength="150"></textarea>
           </nz-form-control>
         </nz-form-item>
 
         <nz-form-item>
-          <nz-form-label nzRequired>
+          <nz-form-label>
             {{ 'submitApp.fields.shortDescAr' | translate }}
             <span class="char-count" [class.warning]="shortDescArCount > 150">
               ({{ shortDescArCount }}/150)
@@ -136,8 +135,7 @@
               [(ngModel)]="formData.short_description_ar"
               name="short_description_ar"
               [placeholder]="'submitApp.placeholders.shortDescAr' | translate"
-              maxlength="150"
-            required></textarea>
+              maxlength="150"></textarea>
           </nz-form-control>
         </nz-form-item>
 
@@ -172,7 +170,7 @@
           {{ 'submitApp.sections.storeLinks' | translate }}
         </h2>
 
-        @if (!hasStoreLink) {
+        @if (!hasStoreLink && (submitForm.submitted || googlePlayCtrl.touched || appStoreCtrl.touched || appGalleryCtrl.touched)) {
           <nz-alert
             nzType="warning"
             [nzMessage]="'submitApp.validation.storeLink' | translate"
@@ -183,30 +181,36 @@
 
         <nz-form-item>
           <nz-form-label>{{ 'submitApp.fields.googlePlay' | translate }}</nz-form-label>
-          <nz-form-control>
+          <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
             <input nz-input
+              #googlePlayCtrl="ngModel"
               [(ngModel)]="formData.google_play_link"
               name="google_play_link"
+              [pattern]="storeLinkPattern"
               [placeholder]="'submitApp.placeholders.googlePlay' | translate" />
           </nz-form-control>
         </nz-form-item>
 
         <nz-form-item>
           <nz-form-label>{{ 'submitApp.fields.appStore' | translate }}</nz-form-label>
-          <nz-form-control>
+          <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
             <input nz-input
+              #appStoreCtrl="ngModel"
               [(ngModel)]="formData.app_store_link"
               name="app_store_link"
+              [pattern]="storeLinkPattern"
               [placeholder]="'submitApp.placeholders.appStore' | translate" />
           </nz-form-control>
         </nz-form-item>
 
         <nz-form-item>
           <nz-form-label>{{ 'submitApp.fields.appGallery' | translate }}</nz-form-label>
-          <nz-form-control>
+          <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
             <input nz-input
+              #appGalleryCtrl="ngModel"
               [(ngModel)]="formData.app_gallery_link"
               name="app_gallery_link"
+              [pattern]="storeLinkPattern"
               [placeholder]="'submitApp.placeholders.appGallery' | translate" />
           </nz-form-control>
         </nz-form-item>
@@ -230,7 +234,7 @@
         </h2>
 
         <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.fields.categories' | translate }}</nz-form-label>
+          <nz-form-label>{{ 'submitApp.fields.categories' | translate }}</nz-form-label>
           <nz-form-control>
             <nz-select
               [(ngModel)]="formData.categories"
@@ -259,13 +263,12 @@
         </h2>
 
         <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.fields.devNameEn' | translate }}</nz-form-label>
+          <nz-form-label>{{ 'submitApp.fields.devNameEn' | translate }}</nz-form-label>
           <nz-form-control>
             <input nz-input
               [(ngModel)]="formData.developer_name_en"
               name="developer_name_en"
-              [placeholder]="'submitApp.placeholders.devNameEn' | translate"
-              required />
+              [placeholder]="'submitApp.placeholders.devNameEn' | translate" />
           </nz-form-control>
         </nz-form-item>
 
@@ -310,68 +313,29 @@
         </h2>
 
         <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.iconUpload' | translate }}</nz-form-label>
-          <nz-form-control>
-            <div class="icon-upload-container">
-              <nz-upload
-                nzType="drag"
-                [nzCustomRequest]="customIconUpload"
-                [nzBeforeUpload]="beforeIconUpload"
-                [nzFileList]="iconFileList"
-                [nzRemove]="onIconRemove"
-                nzListType="picture-card"
-                [nzAccept]="'.png,.jpg,.jpeg,.webp'"
-                [nzLimit]="1"
-                [nzDisabled]="iconUploading"
-                class="icon-uploader">
-                @if (iconFileList.length === 0) {
-                  <div class="upload-drag-content">
-                    @if (iconUploading) {
-                      <span nz-icon nzType="loading" class="upload-icon"></span>
-                    } @else {
-                      <span nz-icon nzType="cloud-upload" class="upload-icon"></span>
-                    }
-                    <p class="upload-text">{{ 'submitApp.iconUploadButton' | translate }}</p>
-                    <p class="upload-hint">{{ 'submitApp.iconUploadHint' | translate }}</p>
-                  </div>
-                }
-              </nz-upload>
-              @if (iconUploadError) {
-                <div class="upload-error">{{ iconUploadError }}</div>
-              }
-              @if (!formData.app_icon_url && !iconUploading) {
-                <div class="field-hint upload-required-hint">{{ 'submitApp.iconRequired' | translate }}</div>
-              }
-            </div>
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.fields.mainImageEn' | translate }}</nz-form-label>
+          <nz-form-label>{{ 'submitApp.fields.mainImageEn' | translate }}</nz-form-label>
           <nz-form-control>
             <input nz-input
               [(ngModel)]="formData.main_image_en"
               name="main_image_en"
-              [placeholder]="'submitApp.placeholders.mainImageEn' | translate"
-              required />
+              [placeholder]="'submitApp.placeholders.mainImageEn' | translate" />
           </nz-form-control>
           <div class="field-hint">{{ 'submitApp.hints.mainImage' | translate }}</div>
         </nz-form-item>
 
         <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.fields.mainImageAr' | translate }}</nz-form-label>
+          <nz-form-label>{{ 'submitApp.fields.mainImageAr' | translate }}</nz-form-label>
           <nz-form-control>
             <input nz-input
               dir="rtl"
               [(ngModel)]="formData.main_image_ar"
               name="main_image_ar"
-              [placeholder]="'submitApp.placeholders.mainImageAr' | translate"
-              required />
+              [placeholder]="'submitApp.placeholders.mainImageAr' | translate" />
           </nz-form-control>
         </nz-form-item>
 
         <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.fields.screenshotsEn' | translate }}</nz-form-label>
+          <nz-form-label>{{ 'submitApp.fields.screenshotsEn' | translate }}</nz-form-label>
           <nz-form-control>
             <textarea nz-input
               [nzAutosize]="{ minRows: 3, maxRows: 6 }"
@@ -389,7 +353,7 @@
         </nz-form-item>
 
         <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.fields.screenshotsAr' | translate }}</nz-form-label>
+          <nz-form-label>{{ 'submitApp.fields.screenshotsAr' | translate }}</nz-form-label>
           <nz-form-control>
             <textarea nz-input
               dir="rtl"

--- a/src/app/pages/submit-app/submit-app.component.ts
+++ b/src/app/pages/submit-app/submit-app.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink, ActivatedRoute } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { Subject, takeUntil, of, Observable, from, Subscription } from 'rxjs';
+import { Subject, takeUntil, of, Observable, from } from 'rxjs';
 import { catchError, map, tap, toArray, mergeMap } from 'rxjs/operators';
 
 import { NzFormModule } from 'ng-zorro-antd/form';
@@ -11,7 +11,6 @@ import { NzInputModule } from 'ng-zorro-antd/input';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
 import { NzSelectModule } from 'ng-zorro-antd/select';
-import { NzUploadModule, NzUploadFile, NzUploadXHRArgs } from 'ng-zorro-antd/upload';
 import { NzMessageService } from 'ng-zorro-antd/message';
 import { NzModalService, NzModalModule } from 'ng-zorro-antd/modal';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -82,7 +81,6 @@ interface FormData {
     NzButtonModule,
     NzCheckboxModule,
     NzSelectModule,
-    NzUploadModule,
     NzModalModule,
     NzIconModule,
     NzSpinModule,
@@ -140,15 +138,7 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
   completedUploads = 0;
   currentLang: 'en' | 'ar' = 'en';
 
-  // Icon upload state
-  iconFileList: NzUploadFile[] = [];
-  iconUploading = false;
-  iconUploadError: string | null = null;
-  private iconUploadSubscription: Subscription | null = null;
-
-  // Icon validation constants
-  readonly MAX_ICON_SIZE = 512 * 1024; // 512 KB
-  readonly ALLOWED_ICON_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+  readonly storeLinkPattern = '^https?://.+';
 
   constructor(
     private submissionService: SubmissionService,
@@ -190,9 +180,6 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
-    if (this.iconUploadSubscription) {
-      this.iconUploadSubscription.unsubscribe();
-    }
   }
 
   private loadCategories(): void {
@@ -217,7 +204,18 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
   }
 
   get hasStoreLink(): boolean {
-    return !!(this.formData.google_play_link || this.formData.app_store_link);
+    return [this.formData.google_play_link, this.formData.app_store_link, this.formData.app_gallery_link]
+      .some(link => this.isValidStoreUrl(link));
+  }
+
+  isValidStoreUrl(url: string): boolean {
+    if (!url) return false;
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
   }
 
   get shortDescEnCount(): number {
@@ -243,97 +241,10 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
     this.formData.screenshots_ar = this.parseScreenshots(this.formData.screenshots_ar_input);
   }
 
-  /**
-   * Client-side validation before icon upload
-   */
-  beforeIconUpload = (file: NzUploadFile): boolean => {
-    this.iconUploadError = null;
-
-    // Check file type
-    const isAllowedType = this.ALLOWED_ICON_TYPES.includes(file.type || '');
-    if (!isAllowedType) {
-      const errorMsg = this.translate.instant('submitApp.iconTypeError');
-      this.iconUploadError = errorMsg;
-      this.message.error(errorMsg);
-      return false;
-    }
-
-    // Check file size
-    const isWithinSize = (file.size || 0) <= this.MAX_ICON_SIZE;
-    if (!isWithinSize) {
-      const errorMsg = this.translate.instant('submitApp.iconSizeError');
-      this.iconUploadError = errorMsg;
-      this.message.error(errorMsg);
-      return false;
-    }
-
-    return true;
-  };
-
-  /**
-   * Custom upload handler for icon file
-   */
-  customIconUpload = (item: NzUploadXHRArgs): Subscription => {
-    this.iconUploading = true;
-    this.iconUploadError = null;
-
-    const file = item.file as unknown as File;
-
-    this.iconUploadSubscription = this.submissionService.uploadMedia(file, 'icon')
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: (response) => {
-          this.iconUploading = false;
-          this.formData.app_icon_url = response.url;
-          this.iconFileList = [{
-            uid: '-1',
-            name: file.name,
-            status: 'done',
-            url: response.url,
-            thumbUrl: response.url
-          }];
-          this.message.success(this.translate.instant('submitApp.iconUploadSuccess'));
-          if (item.onSuccess) {
-            item.onSuccess(response, item.file, null);
-          }
-        },
-        error: (error) => {
-          this.iconUploading = false;
-          const errorMsg = this.translate.instant('submitApp.iconUploadError');
-          this.iconUploadError = errorMsg;
-          this.message.error(errorMsg);
-          if (item.onError) {
-            item.onError(error, item.file);
-          }
-        }
-      });
-
-    return this.iconUploadSubscription;
-  };
-
-  /**
-   * Handle icon removal
-   */
-  onIconRemove = (): boolean => {
-    this.formData.app_icon_url = '';
-    this.iconFileList = [];
-    this.iconUploadError = null;
-    return true;
-  };
-
   isFormValid(): boolean {
-    // Required fields
-    if (!this.formData.submitter_name || !this.formData.submitter_email) return false;
-    if (!this.formData.app_name_en || !this.formData.app_name_ar) return false;
-    if (!this.formData.short_description_en || !this.formData.short_description_ar) return false;
-    if (!this.formData.developer_name_en) return false;
+    if (!this.formData.app_name_en || !this.formData.app_name_en.trim()) return false;
+    if (!this.formData.submitter_email || !this.formData.submitter_email.includes('@')) return false;
     if (!this.hasStoreLink) return false;
-    if (this.formData.categories.length === 0) return false;
-    if (!this.formData.app_icon_url) return false;
-    if (!this.formData.main_image_en || !this.formData.main_image_ar) return false;
-    if (this.formData.screenshots_en.length === 0) return false;
-    if (this.formData.screenshots_ar.length === 0) return false;
-    if (!this.formData.content_confirmation) return false;
 
     return true;
   }
@@ -375,7 +286,7 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
           developer_name_ar: this.formData.developer_name_ar,
           developer_website: this.formData.developer_website,
           developer_email: this.formData.developer_email,
-          app_icon_url: uploadedUrls.icon_url,
+          app_icon_url: this.formData.app_icon_url,
           main_image_en: uploadedUrls.main_image_en,
           main_image_ar: uploadedUrls.main_image_ar,
           screenshots_en: uploadedUrls.screenshots_en,
@@ -410,7 +321,6 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
   }
 
   private uploadAllImages(): Observable<{
-    icon_url: string;
     main_image_en: string;
     main_image_ar: string;
     screenshots_en: string[];
@@ -426,9 +336,6 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
     const uploadTasks: UploadTask[] = [];
 
     // Collect all upload tasks
-    if (this.formData.app_icon_url && this.isExternalUrl(this.formData.app_icon_url)) {
-      uploadTasks.push({ key: 'icon', url: this.formData.app_icon_url, mediaType: 'icon' });
-    }
     if (this.formData.main_image_en && this.isExternalUrl(this.formData.main_image_en)) {
       uploadTasks.push({ key: 'main_en', url: this.formData.main_image_en, mediaType: 'screenshot_en' });
     }
@@ -449,7 +356,6 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
     // If no uploads needed, return original URLs immediately
     if (uploadTasks.length === 0) {
       return of({
-        icon_url: this.formData.app_icon_url,
         main_image_en: this.formData.main_image_en,
         main_image_ar: this.formData.main_image_ar,
         screenshots_en: this.formData.screenshots_en,
@@ -485,16 +391,13 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
         this.isUploading = false;
       }),
       map((results) => {
-        let iconUrl = this.formData.app_icon_url;
         let mainImageEn = this.formData.main_image_en;
         let mainImageAr = this.formData.main_image_ar;
         const screenshotsEn = [...this.formData.screenshots_en];
         const screenshotsAr = [...this.formData.screenshots_ar];
 
         results.forEach((result) => {
-          if (result.key === 'icon') {
-            iconUrl = result.uploadedUrl;
-          } else if (result.key === 'main_en') {
+          if (result.key === 'main_en') {
             mainImageEn = result.uploadedUrl;
           } else if (result.key === 'main_ar') {
             mainImageAr = result.uploadedUrl;
@@ -506,7 +409,6 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
         });
 
         return {
-          icon_url: iconUrl,
           main_image_en: mainImageEn,
           main_image_ar: mainImageAr,
           screenshots_en: screenshotsEn,

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -2,7 +2,7 @@ import { Injectable, PLATFORM_ID, Inject, makeStateKey, TransferState } from '@a
 import { isPlatformServer, isPlatformBrowser } from '@angular/common';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, BehaviorSubject, of } from 'rxjs';
-import { catchError, map, tap, take } from 'rxjs/operators';
+import { catchError, map, tap, take, switchMap } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 
 // Transfer state keys for SSR hydration
@@ -144,6 +144,7 @@ export class ApiService {
   /**
    * Get all published applications with optional filtering and search
    * Uses TransferState for SSR hydration and ETag caching
+   * For home page requests (no params), fetches all pages sequentially
    */
   getApps(params?: {
     search?: string;
@@ -179,25 +180,75 @@ export class ApiService {
       });
     }
 
+    // For home page requests, fetch only the first page (infinite scroll handles the rest)
+    if (isHomePageRequest) {
+      return this.http.get<AppListResponse>(`${this.apiUrl}/apps/`, { params: httpParams }).pipe(
+        tap(response => {
+          this.setLoading(false);
+          this.appsSubject.next(response.results);
+
+          // Cache in localStorage for future visits (browser only)
+          if (isPlatformBrowser(this.platformId)) {
+            this.writeCache(APPS_CACHE_KEY, response.results);
+          }
+
+          // On server, store data in TransferState for client hydration
+          if (isPlatformServer(this.platformId)) {
+            this.transferState.set(APPS_STATE_KEY, response.results);
+          }
+        }),
+        catchError(error => {
+          this.setError('Failed to load applications. Please try again later.');
+          this.setLoading(false);
+          return of({ count: 0, next: null, previous: null, results: [] });
+        })
+      );
+    }
+
+    // For filtered requests (search, category, etc.), return single page
     return this.http.get<AppListResponse>(`${this.apiUrl}/apps/`, { params: httpParams }).pipe(
       tap(response => {
         this.setLoading(false);
         this.appsSubject.next(response.results);
-
-        // Cache in localStorage for future visits (browser only, home page only)
-        if (isPlatformBrowser(this.platformId) && isHomePageRequest) {
-          this.writeCache(APPS_CACHE_KEY, response.results);
-        }
-
-        // On server, store data in TransferState for client hydration (only for home page)
-        if (isPlatformServer(this.platformId) && isHomePageRequest) {
-          this.transferState.set(APPS_STATE_KEY, response.results);
-        }
       }),
       catchError(error => {
         this.setError('Failed to load applications. Please try again later.');
         this.setLoading(false);
         return of({ count: 0, next: null, previous: null, results: [] });
+      })
+    );
+  }
+
+  /**
+   * Load the next page of apps and append to the existing list.
+   * Returns an Observable that emits the updated total count when done.
+   * Used for infinite scroll in the component.
+   */
+  loadNextPage(): Observable<number> {
+    const currentApps = this.appsSubject.value;
+    const currentPage = currentApps.length > 0
+      ? Math.ceil(currentApps.length / 100) + 1
+      : 2;
+
+    let params = new HttpParams().set('page', currentPage.toString());
+
+    return this.http.get<AppListResponse>(`${this.apiUrl}/apps/`, { params }).pipe(
+      tap(response => {
+        const updatedApps = [...currentApps, ...response.results];
+        this.appsSubject.next(updatedApps);
+
+        // Update cache
+        if (isPlatformBrowser(this.platformId)) {
+          this.writeCache(APPS_CACHE_KEY, updatedApps);
+        }
+        if (isPlatformServer(this.platformId)) {
+          this.transferState.set(APPS_STATE_KEY, updatedApps);
+        }
+      }),
+      map(response => response.count ?? currentApps.length),
+      catchError(error => {
+        this.setError('Failed to load more applications.');
+        return of(currentApps.length);
       })
     );
   }

--- a/src/app/services/submission.service.ts
+++ b/src/app/services/submission.service.ts
@@ -11,25 +11,25 @@ export interface SubmissionRequest {
   submitter_organization?: string;
   is_developer: boolean;
 
-  // App Details (Bilingual)
+  // App Details (Bilingual) - only app_name_en is required
   app_name_en: string;
-  app_name_ar: string;
-  short_description_en: string;
-  short_description_ar: string;
+  app_name_ar?: string;
+  short_description_en?: string;
+  short_description_ar?: string;
   description_en?: string;
   description_ar?: string;
 
-  // Store Links
+  // Store Links (at least one valid link required)
   google_play_link?: string;
   app_store_link?: string;
   app_gallery_link?: string;
   website_link?: string;
 
-  // Categories (list of category IDs)
-  categories: number[];
+  // Categories (list of category IDs, optional)
+  categories?: number[];
 
   // Developer Info
-  developer_name_en: string;
+  developer_name_en?: string;
   developer_name_ar?: string;
   developer_website?: string;
   developer_email?: string;

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -260,7 +260,9 @@
       "additionalNotes": "أي معلومات إضافية عن تطبيقك..."
     },
     "validation": {
-      "storeLink": "مطلوب رابط متجر واحد على الأقل (Google Play أو App Store)"
+      "storeLink": "مطلوب رابط متجر واحد صالح على الأقل",
+      "appNameRequired": "يرجى إدخال اسم التطبيق",
+      "invalidStoreLink": "يرجى إدخال رابط متجر صالح"
     },
     "hints": {
       "iconUrl": "يُفضل: صورة PNG أو JPG بحجم 512×512",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -260,7 +260,9 @@
       "additionalNotes": "Any additional information about your app..."
     },
     "validation": {
-      "storeLink": "At least one store link (Google Play or App Store) is required"
+      "storeLink": "At least one valid store link is required",
+      "appNameRequired": "Please enter an app name",
+      "invalidStoreLink": "Please enter a valid Store Link"
     },
     "hints": {
       "iconUrl": "Recommended: 512x512 PNG or JPG image",


### PR DESCRIPTION
## Summary
- Removes the app icon upload requirement from the public submission form (root cause of submission failures per the Notion ticket) - only App Name and a valid Store Link remain required.
- Adds real URL-format validation for store links and clear error messages ("Please enter an app name", "Please enter a valid Store Link") on both frontend and backend.
- Backend: `approve_submission` now blocks with a clear error if a submission has no icon/main images on file, instead of silently publishing a broken listing, since the form no longer collects them.