### PR TITLE
Submit-App Redesign: Hero Card + Live Preview + 3-Step Wizard

### DIFF
--- a/src/app/pages/submit-app/submit-app.component.html
+++ b/src/app/pages/submit-app/submit-app.component.html
@@ -1,7 +1,12 @@
 <div class="submit-app-container">
-  <div class="page-header">
-    <h1>{{ 'submitApp.title' | translate }}</h1>
-    <p>{{ 'submitApp.subtitle' | translate }}</p>
+  <div class="hero-card">
+    <div class="hero-blob hero-blob-teal"></div>
+    <div class="hero-blob hero-blob-gold"></div>
+    <div class="hero-content">
+      <span class="hero-tag">{{ 'submitApp.heroTag' | translate }}</span>
+      <h1>{{ 'submitApp.title' | translate }}</h1>
+      <p>{{ 'submitApp.subtitle' | translate }}</p>
+    </div>
   </div>
 
   <!-- Track existing submission link -->
@@ -14,402 +19,486 @@
     </a>
   </div>
 
-  <nz-spin [nzSpinning]="isLoading">
+  <div class="form-layout">
+  <nz-spin [nzSpinning]="isLoading" class="form-main">
     <form #submitForm="ngForm" (ngSubmit)="onSubmit()">
 
-      <!-- Section 1: Contact Information -->
-      <nz-card class="form-section">
-        <h2 class="section-title">
-          <span nz-icon nzType="user" nzTheme="outline"></span>
-          {{ 'submitApp.sections.contact' | translate }}
-        </h2>
-
-        <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.fields.yourName' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              [(ngModel)]="formData.submitter_name"
-              name="submitter_name"
-              [placeholder]="'submitApp.placeholders.yourName' | translate"
-              required />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.fields.yourEmail' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              type="email"
-              [(ngModel)]="formData.submitter_email"
-              name="submitter_email"
-              [placeholder]="'submitApp.placeholders.yourEmail' | translate"
-              required />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.phone' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              [(ngModel)]="formData.submitter_phone"
-              name="submitter_phone"
-              [placeholder]="'submitApp.placeholders.phone' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.organization' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              [(ngModel)]="formData.submitter_organization"
-              name="submitter_organization"
-              [placeholder]="'submitApp.placeholders.organization' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <div class="checkbox-item">
-          <label nz-checkbox [(ngModel)]="formData.is_developer" name="is_developer">
-            {{ 'submitApp.fields.isDeveloper' | translate }}
-          </label>
-        </div>
-      </nz-card>
-
-      <!-- Section 2: App Details -->
-      <nz-card class="form-section">
-        <h2 class="section-title">
-          <span nz-icon nzType="mobile" nzTheme="outline"></span>
-          {{ 'submitApp.sections.appDetails' | translate }}
-        </h2>
-
-        <nz-form-item>
-          <nz-form-label nzRequired>{{ 'submitApp.fields.appNameEn' | translate }}</nz-form-label>
-          <nz-form-control [nzErrorTip]="'submitApp.validation.appNameRequired' | translate">
-            <input nz-input
-              #appNameEnCtrl="ngModel"
-              [(ngModel)]="formData.app_name_en"
-              name="app_name_en"
-              [placeholder]="'submitApp.placeholders.appNameEn' | translate"
-              required />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.appNameAr' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              dir="rtl"
-              [(ngModel)]="formData.app_name_ar"
-              name="app_name_ar"
-              [placeholder]="'submitApp.placeholders.appNameAr' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>
-            {{ 'submitApp.fields.shortDescEn' | translate }}
-            <span class="char-count" [class.warning]="shortDescEnCount > 150">
-              ({{ shortDescEnCount }}/150)
-            </span>
-          </nz-form-label>
-          <nz-form-control>
-            <textarea nz-input
-              [nzAutosize]="{ minRows: 2, maxRows: 4 }"
-              [(ngModel)]="formData.short_description_en"
-              name="short_description_en"
-              [placeholder]="'submitApp.placeholders.shortDescEn' | translate"
-              maxlength="150"></textarea>
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>
-            {{ 'submitApp.fields.shortDescAr' | translate }}
-            <span class="char-count" [class.warning]="shortDescArCount > 150">
-              ({{ shortDescArCount }}/150)
-            </span>
-          </nz-form-label>
-          <nz-form-control>
-            <textarea nz-input
-              dir="rtl"
-              [nzAutosize]="{ minRows: 2, maxRows: 4 }"
-              [(ngModel)]="formData.short_description_ar"
-              name="short_description_ar"
-              [placeholder]="'submitApp.placeholders.shortDescAr' | translate"
-              maxlength="150"></textarea>
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.descEn' | translate }}</nz-form-label>
-          <nz-form-control>
-            <textarea nz-input
-              [nzAutosize]="{ minRows: 4, maxRows: 8 }"
-              [(ngModel)]="formData.description_en"
-              name="description_en"
-            [placeholder]="'submitApp.placeholders.descEn' | translate"></textarea>
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.descAr' | translate }}</nz-form-label>
-          <nz-form-control>
-            <textarea nz-input
-              dir="rtl"
-              [nzAutosize]="{ minRows: 4, maxRows: 8 }"
-              [(ngModel)]="formData.description_ar"
-              name="description_ar"
-            [placeholder]="'submitApp.placeholders.descAr' | translate"></textarea>
-          </nz-form-control>
-        </nz-form-item>
-      </nz-card>
-
-      <!-- Section 3: Store Links -->
-      <nz-card class="form-section">
-        <h2 class="section-title">
-          <span nz-icon nzType="link" nzTheme="outline"></span>
-          {{ 'submitApp.sections.storeLinks' | translate }}
-        </h2>
-
-        @if (!hasStoreLink && (submitForm.submitted || googlePlayCtrl.touched || appStoreCtrl.touched || appGalleryCtrl.touched)) {
-          <nz-alert
-            nzType="warning"
-            [nzMessage]="'submitApp.validation.storeLink' | translate"
-            nzShowIcon
-            class="store-link-warning">
-          </nz-alert>
+      <!-- Step indicator -->
+      <div class="step-indicator">
+        @for (step of [0, 1, 2]; track step) {
+          <div class="step-dot" [class.active]="currentStep === step" [class.done]="currentStep > step">
+            {{ step + 1 }}
+          </div>
+          @if (step < 2) {
+            <div class="step-line" [class.done]="currentStep > step"></div>
+          }
         }
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.googlePlay' | translate }}</nz-form-label>
-          <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
-            <input nz-input
-              #googlePlayCtrl="ngModel"
-              [(ngModel)]="formData.google_play_link"
-              name="google_play_link"
-              [pattern]="storeLinkPattern"
-              [placeholder]="'submitApp.placeholders.googlePlay' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.appStore' | translate }}</nz-form-label>
-          <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
-            <input nz-input
-              #appStoreCtrl="ngModel"
-              [(ngModel)]="formData.app_store_link"
-              name="app_store_link"
-              [pattern]="storeLinkPattern"
-              [placeholder]="'submitApp.placeholders.appStore' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.appGallery' | translate }}</nz-form-label>
-          <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
-            <input nz-input
-              #appGalleryCtrl="ngModel"
-              [(ngModel)]="formData.app_gallery_link"
-              name="app_gallery_link"
-              [pattern]="storeLinkPattern"
-              [placeholder]="'submitApp.placeholders.appGallery' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.website' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              [(ngModel)]="formData.website_link"
-              name="website_link"
-              [placeholder]="'submitApp.placeholders.website' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-      </nz-card>
-
-      <!-- Section 4: Categories -->
-      <nz-card class="form-section">
-        <h2 class="section-title">
-          <span nz-icon nzType="appstore" nzTheme="outline"></span>
-          {{ 'submitApp.sections.categories' | translate }}
-        </h2>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.categories' | translate }}</nz-form-label>
-          <nz-form-control>
-            <nz-select
-              [(ngModel)]="formData.categories"
-              name="categories"
-              nzMode="multiple"
-              [nzPlaceHolder]="'submitApp.placeholders.categories' | translate"
-              nzShowSearch
-              nzAllowClear
-              [nzMaxTagCount]="5">
-              @for (cat of categories; track cat) {
-                <nz-option
-                  [nzValue]="cat.id"
-                  [nzLabel]="getCategoryName(cat)">
-                </nz-option>
-              }
-            </nz-select>
-          </nz-form-control>
-        </nz-form-item>
-      </nz-card>
-
-      <!-- Section 5: Developer -->
-      <nz-card class="form-section">
-        <h2 class="section-title">
-          <span nz-icon nzType="code" nzTheme="outline"></span>
-          {{ 'submitApp.sections.developer' | translate }}
-        </h2>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.devNameEn' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              [(ngModel)]="formData.developer_name_en"
-              name="developer_name_en"
-              [placeholder]="'submitApp.placeholders.devNameEn' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.devNameAr' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              dir="rtl"
-              [(ngModel)]="formData.developer_name_ar"
-              name="developer_name_ar"
-              [placeholder]="'submitApp.placeholders.devNameAr' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.devWebsite' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              [(ngModel)]="formData.developer_website"
-              name="developer_website"
-              [placeholder]="'submitApp.placeholders.devWebsite' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.devEmail' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              type="email"
-              [(ngModel)]="formData.developer_email"
-              name="developer_email"
-              [placeholder]="'submitApp.placeholders.devEmail' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-      </nz-card>
-
-      <!-- Section 6: Media -->
-      <nz-card class="form-section">
-        <h2 class="section-title">
-          <span nz-icon nzType="picture" nzTheme="outline"></span>
-          {{ 'submitApp.sections.media' | translate }}
-        </h2>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.mainImageEn' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              [(ngModel)]="formData.main_image_en"
-              name="main_image_en"
-              [placeholder]="'submitApp.placeholders.mainImageEn' | translate" />
-          </nz-form-control>
-          <div class="field-hint">{{ 'submitApp.hints.mainImage' | translate }}</div>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.mainImageAr' | translate }}</nz-form-label>
-          <nz-form-control>
-            <input nz-input
-              dir="rtl"
-              [(ngModel)]="formData.main_image_ar"
-              name="main_image_ar"
-              [placeholder]="'submitApp.placeholders.mainImageAr' | translate" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.screenshotsEn' | translate }}</nz-form-label>
-          <nz-form-control>
-            <textarea nz-input
-              [nzAutosize]="{ minRows: 3, maxRows: 6 }"
-              [(ngModel)]="formData.screenshots_en_input"
-              name="screenshots_en_input"
-              (ngModelChange)="onScreenshotsEnChange()"
-            [placeholder]="'submitApp.placeholders.screenshots' | translate"></textarea>
-          </nz-form-control>
-          <div class="field-hint">{{ 'submitApp.hints.screenshots' | translate }}</div>
-          @if (formData.screenshots_en.length > 0) {
-            <div class="screenshot-count">
-              {{ formData.screenshots_en.length }} {{ 'submitApp.screenshotsDetected' | translate }}
-            </div>
-          }
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label>{{ 'submitApp.fields.screenshotsAr' | translate }}</nz-form-label>
-          <nz-form-control>
-            <textarea nz-input
-              dir="rtl"
-              [nzAutosize]="{ minRows: 3, maxRows: 6 }"
-              [(ngModel)]="formData.screenshots_ar_input"
-              name="screenshots_ar_input"
-              (ngModelChange)="onScreenshotsArChange()"
-            [placeholder]="'submitApp.placeholders.screenshots' | translate"></textarea>
-          </nz-form-control>
-          @if (formData.screenshots_ar.length > 0) {
-            <div class="screenshot-count">
-              {{ formData.screenshots_ar.length }} {{ 'submitApp.screenshotsDetected' | translate }}
-            </div>
-          }
-        </nz-form-item>
-      </nz-card>
-
-      <!-- Section 7: Additional Notes -->
-      <nz-card class="form-section">
-        <h2 class="section-title">
-          <span nz-icon nzType="file-text" nzTheme="outline"></span>
-          {{ 'submitApp.sections.additional' | translate }}
-        </h2>
-
-        <nz-form-item>
-          <nz-form-control>
-            <textarea nz-input
-              [nzAutosize]="{ minRows: 3, maxRows: 6 }"
-              [(ngModel)]="formData.additional_notes"
-              name="additional_notes"
-            [placeholder]="'submitApp.placeholders.additionalNotes' | translate"></textarea>
-          </nz-form-control>
-        </nz-form-item>
-      </nz-card>
-
-      <!-- Content Confirmation -->
-      <nz-card class="form-section confirmation-section">
-        <label nz-checkbox [(ngModel)]="formData.content_confirmation" name="content_confirmation">
-          <span class="confirmation-text">
-            {{ 'submitApp.fields.contentConfirmation' | translate }}
-          </span>
-        </label>
-      </nz-card>
-
-      <!-- Submit Button -->
-      <div class="submit-section">
-        <button nz-button
-          nzType="primary"
-          nzSize="large"
-          [nzLoading]="isSubmitting"
-          [disabled]="!isFormValid()">
-          <span nz-icon nzType="send" nzTheme="outline"></span>
-          {{ 'submitApp.submitButton' | translate }}
-        </button>
       </div>
+      <div class="step-labels">
+        <span [class.active]="currentStep === 0">{{ 'submitApp.steps.essentials' | translate }}</span>
+        <span [class.active]="currentStep === 1">{{ 'submitApp.steps.details' | translate }}</span>
+        <span [class.active]="currentStep === 2">{{ 'submitApp.steps.developerMedia' | translate }}</span>
+      </div>
+
+      @if (currentStep === 0) {
+        <!-- Step 1: Contact -->
+        <nz-card class="form-section">
+          <h2 class="section-title">
+            <span nz-icon nzType="user" nzTheme="outline"></span>
+            {{ 'submitApp.sections.contact' | translate }}
+          </h2>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.yourName' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                [(ngModel)]="formData.submitter_name"
+                name="submitter_name"
+                [placeholder]="'submitApp.placeholders.yourName' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label nzRequired>{{ 'submitApp.fields.yourEmail' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                type="email"
+                [(ngModel)]="formData.submitter_email"
+                name="submitter_email"
+                [placeholder]="'submitApp.placeholders.yourEmail' | translate"
+                required />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.phone' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                [(ngModel)]="formData.submitter_phone"
+                name="submitter_phone"
+                [placeholder]="'submitApp.placeholders.phone' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.organization' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                [(ngModel)]="formData.submitter_organization"
+                name="submitter_organization"
+                [placeholder]="'submitApp.placeholders.organization' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+
+          <div class="checkbox-item">
+            <label nz-checkbox [(ngModel)]="formData.is_developer" name="is_developer">
+              {{ 'submitApp.fields.isDeveloper' | translate }}
+            </label>
+          </div>
+        </nz-card>
+
+        <!-- Step 1: App Name -->
+        <nz-card class="form-section">
+          <h2 class="section-title">
+            <span nz-icon nzType="mobile" nzTheme="outline"></span>
+            {{ 'submitApp.sections.appDetails' | translate }}
+          </h2>
+
+          <nz-form-item>
+            <nz-form-label nzRequired>{{ 'submitApp.fields.appNameEn' | translate }}</nz-form-label>
+            <nz-form-control [nzErrorTip]="'submitApp.validation.appNameRequired' | translate">
+              <input nz-input
+                #appNameEnCtrl="ngModel"
+                [(ngModel)]="formData.app_name_en"
+                name="app_name_en"
+                [placeholder]="'submitApp.placeholders.appNameEn' | translate"
+                required />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.appNameAr' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                dir="rtl"
+                [(ngModel)]="formData.app_name_ar"
+                name="app_name_ar"
+                [placeholder]="'submitApp.placeholders.appNameAr' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+        </nz-card>
+
+        <!-- Step 1: Store Links -->
+        <nz-card class="form-section">
+          <h2 class="section-title">
+            <span nz-icon nzType="link" nzTheme="outline"></span>
+            {{ 'submitApp.sections.storeLinks' | translate }}
+          </h2>
+
+          @if (!hasStoreLink && (submitForm.submitted || googlePlayCtrl.touched || appStoreCtrl.touched || appGalleryCtrl.touched)) {
+            <nz-alert
+              nzType="warning"
+              [nzMessage]="'submitApp.validation.storeLink' | translate"
+              nzShowIcon
+              class="store-link-warning">
+            </nz-alert>
+          }
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.googlePlay' | translate }}</nz-form-label>
+            <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
+              <input nz-input
+                #googlePlayCtrl="ngModel"
+                [(ngModel)]="formData.google_play_link"
+                name="google_play_link"
+                [pattern]="storeLinkPattern"
+                [placeholder]="'submitApp.placeholders.googlePlay' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.appStore' | translate }}</nz-form-label>
+            <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
+              <input nz-input
+                #appStoreCtrl="ngModel"
+                [(ngModel)]="formData.app_store_link"
+                name="app_store_link"
+                [pattern]="storeLinkPattern"
+                [placeholder]="'submitApp.placeholders.appStore' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.appGallery' | translate }}</nz-form-label>
+            <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
+              <input nz-input
+                #appGalleryCtrl="ngModel"
+                [(ngModel)]="formData.app_gallery_link"
+                name="app_gallery_link"
+                [pattern]="storeLinkPattern"
+                [placeholder]="'submitApp.placeholders.appGallery' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.website' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                [(ngModel)]="formData.website_link"
+                name="website_link"
+                [placeholder]="'submitApp.placeholders.website' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+        </nz-card>
+
+        <div class="step-nav">
+          <span></span>
+          <button type="button" nz-button nzType="primary" nzSize="large" (click)="nextStep()" [disabled]="!isFormValid()">
+            {{ 'submitApp.stepNav.continue' | translate }}
+            <span nz-icon nzType="arrow-right" nzTheme="outline"></span>
+          </button>
+        </div>
+      }
+
+      @if (currentStep === 1) {
+        <!-- Step 2: Descriptions -->
+        <nz-card class="form-section">
+          <h2 class="section-title">
+            <span nz-icon nzType="file-text" nzTheme="outline"></span>
+            {{ 'submitApp.sections.appDetails' | translate }}
+          </h2>
+
+          <nz-form-item>
+            <nz-form-label>
+              {{ 'submitApp.fields.shortDescEn' | translate }}
+              <span class="char-count" [class.warning]="shortDescEnCount > 150">
+                ({{ shortDescEnCount }}/150)
+              </span>
+            </nz-form-label>
+            <nz-form-control>
+              <textarea nz-input
+                [nzAutosize]="{ minRows: 2, maxRows: 4 }"
+                [(ngModel)]="formData.short_description_en"
+                name="short_description_en"
+                [placeholder]="'submitApp.placeholders.shortDescEn' | translate"
+                maxlength="150"></textarea>
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>
+              {{ 'submitApp.fields.shortDescAr' | translate }}
+              <span class="char-count" [class.warning]="shortDescArCount > 150">
+                ({{ shortDescArCount }}/150)
+              </span>
+            </nz-form-label>
+            <nz-form-control>
+              <textarea nz-input
+                dir="rtl"
+                [nzAutosize]="{ minRows: 2, maxRows: 4 }"
+                [(ngModel)]="formData.short_description_ar"
+                name="short_description_ar"
+                [placeholder]="'submitApp.placeholders.shortDescAr' | translate"
+                maxlength="150"></textarea>
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.descEn' | translate }}</nz-form-label>
+            <nz-form-control>
+              <textarea nz-input
+                [nzAutosize]="{ minRows: 4, maxRows: 8 }"
+                [(ngModel)]="formData.description_en"
+                name="description_en"
+              [placeholder]="'submitApp.placeholders.descEn' | translate"></textarea>
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.descAr' | translate }}</nz-form-label>
+            <nz-form-control>
+              <textarea nz-input
+                dir="rtl"
+                [nzAutosize]="{ minRows: 4, maxRows: 8 }"
+                [(ngModel)]="formData.description_ar"
+                name="description_ar"
+              [placeholder]="'submitApp.placeholders.descAr' | translate"></textarea>
+            </nz-form-control>
+          </nz-form-item>
+        </nz-card>
+
+        <!-- Step 2: Categories -->
+        <nz-card class="form-section">
+          <h2 class="section-title">
+            <span nz-icon nzType="appstore" nzTheme="outline"></span>
+            {{ 'submitApp.sections.categories' | translate }}
+          </h2>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.categories' | translate }}</nz-form-label>
+            <nz-form-control>
+              <nz-select
+                [(ngModel)]="formData.categories"
+                name="categories"
+                nzMode="multiple"
+                [nzPlaceHolder]="'submitApp.placeholders.categories' | translate"
+                nzShowSearch
+                nzAllowClear
+                [nzMaxTagCount]="5">
+                @for (cat of categories; track cat) {
+                  <nz-option
+                    [nzValue]="cat.id"
+                    [nzLabel]="getCategoryName(cat)">
+                  </nz-option>
+                }
+              </nz-select>
+            </nz-form-control>
+          </nz-form-item>
+        </nz-card>
+
+        <div class="step-nav">
+          <button type="button" nz-button nzSize="large" (click)="prevStep()">
+            <span nz-icon nzType="arrow-left" nzTheme="outline"></span>
+            {{ 'submitApp.stepNav.back' | translate }}
+          </button>
+          <button type="button" nz-button nzType="primary" nzSize="large" (click)="nextStep()">
+            {{ 'submitApp.stepNav.continue' | translate }}
+            <span nz-icon nzType="arrow-right" nzTheme="outline"></span>
+          </button>
+        </div>
+      }
+
+      @if (currentStep === 2) {
+        <!-- Step 3: Developer -->
+        <nz-card class="form-section">
+          <h2 class="section-title">
+            <span nz-icon nzType="code" nzTheme="outline"></span>
+            {{ 'submitApp.sections.developer' | translate }}
+          </h2>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.devNameEn' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                [(ngModel)]="formData.developer_name_en"
+                name="developer_name_en"
+                [placeholder]="'submitApp.placeholders.devNameEn' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.devNameAr' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                dir="rtl"
+                [(ngModel)]="formData.developer_name_ar"
+                name="developer_name_ar"
+                [placeholder]="'submitApp.placeholders.devNameAr' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.devWebsite' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                [(ngModel)]="formData.developer_website"
+                name="developer_website"
+                [placeholder]="'submitApp.placeholders.devWebsite' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.devEmail' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                type="email"
+                [(ngModel)]="formData.developer_email"
+                name="developer_email"
+                [placeholder]="'submitApp.placeholders.devEmail' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+        </nz-card>
+
+        <!-- Step 3: Media -->
+        <nz-card class="form-section">
+          <h2 class="section-title">
+            <span nz-icon nzType="picture" nzTheme="outline"></span>
+            {{ 'submitApp.sections.media' | translate }}
+          </h2>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.mainImageEn' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                [(ngModel)]="formData.main_image_en"
+                name="main_image_en"
+                [placeholder]="'submitApp.placeholders.mainImageEn' | translate" />
+            </nz-form-control>
+            <div class="field-hint">{{ 'submitApp.hints.mainImage' | translate }}</div>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.mainImageAr' | translate }}</nz-form-label>
+            <nz-form-control>
+              <input nz-input
+                dir="rtl"
+                [(ngModel)]="formData.main_image_ar"
+                name="main_image_ar"
+                [placeholder]="'submitApp.placeholders.mainImageAr' | translate" />
+            </nz-form-control>
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.screenshotsEn' | translate }}</nz-form-label>
+            <nz-form-control>
+              <textarea nz-input
+                [nzAutosize]="{ minRows: 3, maxRows: 6 }"
+                [(ngModel)]="formData.screenshots_en_input"
+                name="screenshots_en_input"
+                (ngModelChange)="onScreenshotsEnChange()"
+              [placeholder]="'submitApp.placeholders.screenshots' | translate"></textarea>
+            </nz-form-control>
+            <div class="field-hint">{{ 'submitApp.hints.screenshots' | translate }}</div>
+            @if (formData.screenshots_en.length > 0) {
+              <div class="screenshot-count">
+                {{ formData.screenshots_en.length }} {{ 'submitApp.screenshotsDetected' | translate }}
+              </div>
+            }
+          </nz-form-item>
+
+          <nz-form-item>
+            <nz-form-label>{{ 'submitApp.fields.screenshotsAr' | translate }}</nz-form-label>
+            <nz-form-control>
+              <textarea nz-input
+                dir="rtl"
+                [nzAutosize]="{ minRows: 3, maxRows: 6 }"
+                [(ngModel)]="formData.screenshots_ar_input"
+                name="screenshots_ar_input"
+                (ngModelChange)="onScreenshotsArChange()"
+              [placeholder]="'submitApp.placeholders.screenshots' | translate"></textarea>
+            </nz-form-control>
+            @if (formData.screenshots_ar.length > 0) {
+              <div class="screenshot-count">
+                {{ formData.screenshots_ar.length }} {{ 'submitApp.screenshotsDetected' | translate }}
+              </div>
+            }
+          </nz-form-item>
+        </nz-card>
+
+        <!-- Step 3: Additional Notes -->
+        <nz-card class="form-section">
+          <h2 class="section-title">
+            <span nz-icon nzType="message" nzTheme="outline"></span>
+            {{ 'submitApp.sections.additional' | translate }}
+          </h2>
+
+          <nz-form-item>
+            <nz-form-control>
+              <textarea nz-input
+                [nzAutosize]="{ minRows: 3, maxRows: 6 }"
+                [(ngModel)]="formData.additional_notes"
+                name="additional_notes"
+              [placeholder]="'submitApp.placeholders.additionalNotes' | translate"></textarea>
+            </nz-form-control>
+          </nz-form-item>
+        </nz-card>
+
+        <!-- Content Confirmation -->
+        <nz-card class="form-section confirmation-section">
+          <label nz-checkbox [(ngModel)]="formData.content_confirmation" name="content_confirmation">
+            <span class="confirmation-text">
+              {{ 'submitApp.fields.contentConfirmation' | translate }}
+            </span>
+          </label>
+        </nz-card>
+
+        <div class="step-nav">
+          <button type="button" nz-button nzSize="large" (click)="prevStep()">
+            <span nz-icon nzType="arrow-left" nzTheme="outline"></span>
+            {{ 'submitApp.stepNav.back' | translate }}
+          </button>
+          <button nz-button
+            nzType="primary"
+            nzSize="large"
+            [nzLoading]="isSubmitting"
+            [disabled]="!isFormValid()">
+            <span nz-icon nzType="send" nzTheme="outline"></span>
+            {{ 'submitApp.submitButton' | translate }}
+          </button>
+        </div>
+      }
 
     </form>
   </nz-spin>
+
+  <!-- Live preview card -->
+  <aside class="preview-card">
+    <h4 class="preview-label">{{ 'submitApp.preview.label' | translate }}</h4>
+    <div class="preview-app">
+      <div class="preview-icon">
+        <span nz-icon nzType="mobile" nzTheme="outline"></span>
+      </div>
+      <div>
+        <div class="preview-name">
+          {{ formData.app_name_en || ('submitApp.preview.placeholderName' | translate) }}
+        </div>
+        <div class="preview-status">{{ 'submitApp.preview.pendingReview' | translate }}</div>
+      </div>
+    </div>
+    <div class="preview-tags">
+      <span class="tag" [class.tag-done]="hasStoreLink">
+        <span nz-icon [nzType]="hasStoreLink ? 'check-circle' : 'link'" nzTheme="outline"></span>
+        {{ (hasStoreLink ? 'submitApp.preview.storeLinkAdded' : 'submitApp.preview.storeLinkMissing') | translate }}
+      </span>
+      <span class="tag" [class.tag-done]="formData.submitter_email">
+        <span nz-icon [nzType]="formData.submitter_email ? 'check-circle' : 'mail'" nzTheme="outline"></span>
+        {{ (formData.submitter_email ? 'submitApp.preview.emailAdded' : 'submitApp.preview.emailMissing') | translate }}
+      </span>
+    </div>
+    <div class="preview-ready" [class.ready]="isFormValid()">
+      <span nz-icon [nzType]="isFormValid() ? 'check-circle' : 'info-circle'" nzTheme="outline"></span>
+      {{ (isFormValid() ? 'submitApp.preview.readyToSubmit' : 'submitApp.preview.notReadyYet') | translate }}
+    </div>
+  </aside>
+  </div>
 </div>

--- a/src/app/pages/submit-app/submit-app.component.scss
+++ b/src/app/pages/submit-app/submit-app.component.scss
@@ -1,15 +1,56 @@
 .submit-app-container {
-  max-width: 640px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 16px;
 }
 
-.page-header {
+.hero-card {
+  position: relative;
+  overflow: hidden;
   text-align: center;
   margin-bottom: 20px;
-  padding: 24px 16px;
-  background: var(--surface-color, #f8f9fa);
-  border-radius: 8px;
+  padding: 120px 16px 32px;
+  background: var(--card-bg, #fff);
+  border-radius: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+
+  .hero-content {
+    position: relative;
+    z-index: 1;
+  }
+
+  .hero-blob {
+    position: absolute;
+    width: 220px;
+    height: 220px;
+    border-radius: 50%;
+    filter: blur(60px);
+    opacity: 0.2;
+    pointer-events: none;
+  }
+
+  .hero-blob-teal {
+    top: -80px;
+    inset-inline-end: -60px;
+    background: #12bcac;
+  }
+
+  .hero-blob-gold {
+    bottom: -90px;
+    inset-inline-start: -50px;
+    background: #faaf41;
+  }
+
+  .hero-tag {
+    display: inline-block;
+    padding: 4px 14px;
+    margin-bottom: 12px;
+    border-radius: 9999px;
+    font-size: 12px;
+    font-weight: 600;
+    background: rgba(160, 83, 59, 0.08);
+    color: var(--primary-color, #a0533b);
+  }
 
   h1 {
     margin: 0 0 8px 0;
@@ -56,10 +97,115 @@
   }
 }
 
+.form-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+  align-items: start;
+
+  @media (min-width: 768px) {
+    grid-template-columns: minmax(0, 2fr) minmax(220px, 1fr);
+  }
+}
+
+.form-main {
+  min-width: 0;
+}
+
+.preview-card {
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border-color, #dee2e6);
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 20px;
+
+  @media (min-width: 768px) {
+    position: sticky;
+    top: 20px;
+  }
+}
+
+.preview-label {
+  margin: 0 0 12px 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-secondary, #999);
+}
+
+.preview-app {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.preview-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-color, #f8f9fa);
+  color: var(--primary-color, #a0533b);
+  font-size: 18px;
+}
+
+.preview-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-color, #333);
+  word-break: break-word;
+}
+
+.preview-status {
+  font-size: 12px;
+  color: var(--text-secondary, #999);
+}
+
+.preview-tags {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.preview-tags .tag,
+.preview-ready {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 9999px;
+  background: var(--surface-color, #f8f9fa);
+  color: var(--text-secondary, #999);
+  width: fit-content;
+}
+
+.preview-tags .tag.tag-done {
+  background: rgba(160, 83, 59, 0.08);
+  color: var(--primary-color, #a0533b);
+}
+
+.preview-ready {
+  width: 100%;
+  justify-content: center;
+  font-weight: 600;
+
+  &.ready {
+    background: rgba(82, 196, 26, 0.12);
+    color: #389e0d;
+  }
+}
+
 .form-section {
   margin-bottom: 16px;
-  border-radius: 8px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 
   ::ng-deep .ant-card-body {
     padding: 16px;
@@ -127,7 +273,7 @@
 
 ::ng-deep .ant-input,
 ::ng-deep .ant-select-selector {
-  border-radius: 6px !important;
+  border-radius: 8px !important;
 }
 
 ::ng-deep .ant-select {
@@ -161,72 +307,93 @@
   margin-top: 6px;
 }
 
-// Icon upload styles
-.icon-upload-container {
-  width: 100%;
+// Step wizard
+.step-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 12px;
 }
 
-.icon-uploader {
-  ::ng-deep .ant-upload-drag {
-    background: var(--surface-color, #fafafa);
-    border: 2px dashed var(--border-color, #d9d9d9);
-    border-radius: 8px;
-    padding: 16px;
-    transition: border-color 0.3s, background 0.3s;
-    min-height: 120px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.step-dot {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  background: var(--surface-color, #f8f9fa);
+  color: var(--text-secondary, #999);
+  border: 1px solid var(--border-color, #dee2e6);
+  transition: all 0.2s ease;
 
-    &:hover {
-      border-color: var(--primary-color, #a0533b);
-    }
+  &.active {
+    background: var(--primary-color, #a0533b);
+    border-color: var(--primary-color, #a0533b);
+    color: #fff;
   }
 
-  ::ng-deep .ant-upload-list-picture-card {
-    margin-top: 12px;
-
-    .ant-upload-list-item {
-      width: 100px;
-      height: 100px;
-      border-radius: 8px;
-    }
+  &.done {
+    background: rgba(160, 83, 59, 0.12);
+    border-color: var(--primary-color, #a0533b);
+    color: var(--primary-color, #a0533b);
   }
 }
 
-.upload-drag-content {
-  text-align: center;
-  padding: 8px;
+.step-line {
+  width: 40px;
+  height: 2px;
+  background: var(--border-color, #dee2e6);
+
+  &.done {
+    background: var(--primary-color, #a0533b);
+  }
 }
 
-.upload-icon {
-  font-size: 32px;
-  color: var(--primary-color, #a0533b);
-  margin-bottom: 8px;
-}
-
-.upload-text {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-color, #333);
-  margin: 0 0 4px 0;
-}
-
-.upload-hint {
+.step-labels {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  margin-bottom: 20px;
   font-size: 12px;
   color: var(--text-secondary, #999);
-  margin: 0;
+
+  span.active {
+    color: var(--primary-color, #a0533b);
+    font-weight: 600;
+  }
 }
 
-.upload-error {
-  color: #ff4d4f;
-  font-size: 12px;
-  margin-top: 8px;
-}
+.step-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 0 32px;
 
-.upload-required-hint {
-  color: var(--text-secondary, #999);
-  margin-top: 8px;
+  button {
+    min-width: 140px;
+    height: 44px;
+    font-size: 15px;
+    border-radius: 9999px;
+  }
+
+  button[nztype="primary"] {
+    background-color: var(--primary-color, #a0533b);
+    border-color: var(--primary-color, #a0533b);
+
+    &:hover:not(:disabled) {
+      background-color: #8a4632;
+      border-color: #8a4632;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+    }
+  }
 }
 
 .store-link-warning {
@@ -246,29 +413,6 @@
   line-height: 1.5;
 }
 
-.submit-section {
-  text-align: center;
-  padding: 16px 0 32px;
-
-  button {
-    min-width: 180px;
-    height: 44px;
-    font-size: 15px;
-    border-radius: 6px;
-    background-color: var(--primary-color, #a0533b);
-    border-color: var(--primary-color, #a0533b);
-
-    &:hover:not(:disabled) {
-      background-color: #8a4632;
-      border-color: #8a4632;
-    }
-
-    &:disabled {
-      opacity: 0.6;
-    }
-  }
-}
-
 // RTL support
 [dir="rtl"] {
   .section-title [nz-icon] {
@@ -284,8 +428,24 @@
 
 // Dark theme
 :host-context(.dark-theme) {
-  .page-header {
-    background: var(--surface-color, #1a1a1a);
+  .hero-card {
+    background: var(--card-bg, #1f1f1f);
+  }
+
+  .preview-card {
+    background: var(--card-bg, #1f1f1f);
+    border-color: var(--border-color, #333);
+  }
+
+  .preview-icon,
+  .preview-tags .tag,
+  .preview-ready {
+    background: var(--surface-color, #2a2a2a);
+  }
+
+  .step-dot {
+    background: var(--surface-color, #2a2a2a);
+    border-color: var(--border-color, #444);
   }
 
   .track-link-banner {
@@ -314,17 +474,6 @@
   ::ng-deep nz-form-label {
     color: var(--text-color, #e0e0e0);
   }
-
-  .icon-uploader {
-    ::ng-deep .ant-upload-drag {
-      background: var(--surface-color, #2a2a2a);
-      border-color: var(--border-color, #444);
-    }
-  }
-
-  .upload-text {
-    color: var(--text-color, #e0e0e0);
-  }
 }
 
 // Responsive
@@ -333,8 +482,8 @@
     padding: 12px;
   }
 
-  .page-header {
-    padding: 16px 12px;
+  .hero-card {
+    padding: 80px 12px 20px;
 
     h1 {
       font-size: 20px;

--- a/src/app/pages/submit-app/submit-app.component.ts
+++ b/src/app/pages/submit-app/submit-app.component.ts
@@ -140,6 +140,8 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
 
   readonly storeLinkPattern = '^https?://.+';
 
+  currentStep = 0;
+
   constructor(
     private submissionService: SubmissionService,
     private translate: TranslateService,
@@ -239,6 +241,17 @@ export class SubmitAppComponent implements OnInit, OnDestroy {
 
   onScreenshotsArChange(): void {
     this.formData.screenshots_ar = this.parseScreenshots(this.formData.screenshots_ar_input);
+  }
+
+  nextStep(): void {
+    if (this.currentStep === 0 && !this.isFormValid()) return;
+    this.currentStep = Math.min(this.currentStep + 1, 2);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  prevStep(): void {
+    this.currentStep = Math.max(this.currentStep - 1, 0);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
   isFormValid(): boolean {

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -194,6 +194,27 @@
   "submitApp": {
     "title": "أضف تطبيقك",
     "subtitle": "شارك تطبيقك القرآني مع المجتمع",
+    "heroTag": "للمطورين",
+    "steps": {
+      "essentials": "الأساسيات",
+      "details": "تفاصيل التطبيق",
+      "developerMedia": "المطور والوسائط"
+    },
+    "stepNav": {
+      "continue": "متابعة",
+      "back": "رجوع"
+    },
+    "preview": {
+      "label": "معاينة",
+      "placeholderName": "اسم تطبيقك",
+      "pendingReview": "قيد المراجعة",
+      "storeLinkAdded": "تمت إضافة رابط المتجر",
+      "storeLinkMissing": "أضف رابط متجر",
+      "emailAdded": "تمت إضافة البريد الإلكتروني",
+      "emailMissing": "أضف بريدك الإلكتروني",
+      "readyToSubmit": "جاهز للإرسال",
+      "notReadyYet": "غير جاهز بعد"
+    },
     "alreadySubmitted": "هل أرسلت تطبيقاً من قبل؟",
     "trackYourSubmission": "تتبع طلبك",
     "sections": {
@@ -269,14 +290,6 @@
       "mainImage": "الصورة المميزة المعروضة على بطاقات التطبيقات. يُفضل: 600×400 PNG أو JPG",
       "screenshots": "أدخل رابطاً واحداً في كل سطر. يُفضل حتى 5 لقطات."
     },
-    "iconUpload": "أيقونة التطبيق",
-    "iconUploadHint": "صيغة PNG أو JPG أو WebP. الحد الأقصى 512 كيلوبايت.",
-    "iconUploadButton": "انقر أو اسحب لرفع الأيقونة",
-    "iconRequired": "أيقونة التطبيق مطلوبة",
-    "iconSizeError": "يجب أن يكون حجم الأيقونة أقل من 512 كيلوبايت",
-    "iconTypeError": "الصيغ المسموحة فقط: PNG و JPG و WebP",
-    "iconUploadSuccess": "تم رفع الأيقونة بنجاح",
-    "iconUploadError": "فشل في رفع الأيقونة",
     "screenshotsDetected": "لقطة شاشة مكتشفة",
     "submitButton": "إرسال التطبيق",
     "success": {
@@ -366,7 +379,7 @@
       "approved": "مقبول",
       "rejected": "مرفوض"
     }
-  }, 
+  },
   "APP": {
     "NOT_FOUND_TITLE": "التطبيق غير موجود",
     "NOT_FOUND_MESSAGE": "التطبيق الذي تبحث عنه غير متوفر أو ربما تم حذفه.",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -194,6 +194,27 @@
   "submitApp": {
     "title": "Submit Your App",
     "subtitle": "Share your Quran app with the community",
+    "heroTag": "For Developers",
+    "steps": {
+      "essentials": "Essentials",
+      "details": "App Details",
+      "developerMedia": "Developer & Media"
+    },
+    "stepNav": {
+      "continue": "Continue",
+      "back": "Back"
+    },
+    "preview": {
+      "label": "Preview",
+      "placeholderName": "Your App Name",
+      "pendingReview": "Pending review",
+      "storeLinkAdded": "Store link added",
+      "storeLinkMissing": "Add a store link",
+      "emailAdded": "Email added",
+      "emailMissing": "Add your email",
+      "readyToSubmit": "Ready to submit",
+      "notReadyYet": "Not ready yet"
+    },
     "alreadySubmitted": "Already submitted an app?",
     "trackYourSubmission": "Track your submission here",
     "sections": {
@@ -269,14 +290,6 @@
       "mainImage": "Featured image shown on app cards. Recommended: 600x400 PNG or JPG",
       "screenshots": "Enter one URL per line. Up to 5 screenshots recommended."
     },
-    "iconUpload": "Application Icon",
-    "iconUploadHint": "PNG, JPG, or WebP format. Maximum 512KB.",
-    "iconUploadButton": "Click or drag to upload icon",
-    "iconRequired": "Application icon is required",
-    "iconSizeError": "Icon must be less than 512KB",
-    "iconTypeError": "Only PNG, JPG, and WebP formats are allowed",
-    "iconUploadSuccess": "Icon uploaded successfully",
-    "iconUploadError": "Failed to upload icon",
     "screenshotsDetected": "screenshots detected",
     "submitButton": "Submit App",
     "success": {


### PR DESCRIPTION
## Summary
Follow-up to #281 - the simplified submission form still had a generic ng-zorro look inconsistent with the rest of the site. This redesigns the form itself (no backend/validation changes):

- **Branded hero card** with the site's blurred-ellipse decorative motif (reused from about-us/app-list), a "For Developers" pill tag, and tokens matched to the real brand (`#a0533b` primary, 8-10px card radii, `0 2px 8px` shadows, pill-shaped buttons/tags) instead of stock Ant Design defaults.
- **Live preview card** (sticky on desktop) showing the app name, store-link/email status, and a "Ready to submit" indicator that update as the user types.
- **3-step wizard**: Step 1 "Essentials" (contact + app name + store links - the only required fields), Step 2 "App Details" (descriptions + categories, optional), Step 3 "Developer & Media" (optional) + submit.
- Cleaned up dead icon-upload CSS/i18n keys left over from #281, and fixed a UI inconsistency where "Your Name" showed as required but wasn't enforced.

## Test plan
- [x] Full local run: real Postgres + Django dev server + Angular dev server, driven end-to-end through a real headless browser
  - Full 3-step flow (step 1 filled, steps 2-3 skipped since optional) -> 201 -> tracking-ID success modal
  - Verified dark theme and mobile RTL (Arabic) rendering
  - Caught and fixed a real bug in testing: hero title was rendering behind the site's floating/absolute nav bar on initial load; added the same top-padding convention used on about-us/contact-us
- [x] `tsc-check` - only a pre-existing unrelated error in `functions/[[path]].ts` (confirmed present before this branch's changes)