### PR TITLE
Match Submit-App Design to Site System + Fix Contact-Us Request Form Link

### DIFF
--- a/src/app/pages/contact-us/contact-us.component.html
+++ b/src/app/pages/contact-us/contact-us.component.html
@@ -39,9 +39,7 @@
       </a>
 
       <a
-        href="https://forms.gle/62DMnc3YdttVMAby7"
-        target="_blank"
-        rel="noopener noreferrer"
+        [routerLink]="['/', currentLang, 'submit-app']"
         class="contact-card"
       >
         <span class="card-arrow">&#x203a;</span>

--- a/src/app/pages/contact-us/contact-us.component.ts
+++ b/src/app/pages/contact-us/contact-us.component.ts
@@ -1,11 +1,19 @@
 import { Component } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-contact-us',
   standalone: true,
-  imports: [TranslateModule],
+  imports: [TranslateModule, RouterLink],
   templateUrl: './contact-us.component.html',
   styleUrls: ['./contact-us.component.scss']
 })
-export class ContactUsComponent {} 
+export class ContactUsComponent {
+  currentLang: 'en' | 'ar';
+
+  constructor(route: ActivatedRoute, translate: TranslateService) {
+    const routeLang = route.snapshot.paramMap.get('lang');
+    this.currentLang = (routeLang as 'en' | 'ar') || (translate.currentLang as 'en' | 'ar') || 'en';
+  }
+} 

--- a/src/app/pages/submit-app/submit-app.component.html
+++ b/src/app/pages/submit-app/submit-app.component.html
@@ -1,232 +1,240 @@
-<div class="submit-app-container">
-  <div class="hero-card">
-    <div class="hero-blob hero-blob-teal"></div>
-    <div class="hero-blob hero-blob-gold"></div>
+<div class="submit-app-page">
+  <!-- Page-level backgrounds (same as about-us / contact-us) -->
+  <div class="page-background-left">
+    <span class="ellipse-small"></span>
+  </div>
+  <div class="page-background-right">
+    <span class="ellipse-small"></span>
+  </div>
+
+  <!-- Hero Section -->
+  <section class="hero-section">
     <div class="hero-content">
-      <span class="hero-tag">{{ 'submitApp.heroTag' | translate }}</span>
       <h1>{{ 'submitApp.title' | translate }}</h1>
-      <p>{{ 'submitApp.subtitle' | translate }}</p>
+      <p class="description">{{ 'submitApp.subtitle' | translate }}</p>
     </div>
-  </div>
+  </section>
 
-  <!-- Track existing submission link -->
-  <div class="track-link-banner">
-    <span nz-icon nzType="search" nzTheme="outline"></span>
-    <span>{{ 'submitApp.alreadySubmitted' | translate }}</span>
-    <a [routerLink]="['/', currentLang, 'track-submission']">
-      {{ 'submitApp.trackYourSubmission' | translate }}
-      <span nz-icon nzType="arrow-right" nzTheme="outline"></span>
-    </a>
-  </div>
+  <div class="content-container">
+    <!-- Track existing submission link -->
+    <div class="track-link-banner">
+      <span nz-icon nzType="search" nzTheme="outline"></span>
+      <span>{{ 'submitApp.alreadySubmitted' | translate }}</span>
+      <a [routerLink]="['/', currentLang, 'track-submission']">
+        {{ 'submitApp.trackYourSubmission' | translate }}
+        <span nz-icon nzType="arrow-right" nzTheme="outline"></span>
+      </a>
+    </div>
 
-  <div class="form-layout">
-  <nz-spin [nzSpinning]="isLoading" class="form-main">
-    <form #submitForm="ngForm" (ngSubmit)="onSubmit()">
+    <div class="form-layout">
+    <nz-spin [nzSpinning]="isLoading" class="form-main">
+      <form #submitForm="ngForm" (ngSubmit)="onSubmit()">
 
-      @if (currentStep === 0) {
-        <!-- Step 1: Contact -->
-        <nz-card class="form-section">
-          <h2 class="section-title">
-            <span nz-icon nzType="user" nzTheme="outline"></span>
-            {{ 'submitApp.sections.contact' | translate }}
-          </h2>
+        @if (currentStep === 0) {
+          <!-- Step 1: Contact -->
+          <nz-card class="form-section">
+            <h2 class="section-title">
+              <span nz-icon nzType="user" nzTheme="outline"></span>
+              {{ 'submitApp.sections.contact' | translate }}
+            </h2>
 
-          <nz-form-item>
-            <nz-form-label>{{ 'submitApp.fields.yourName' | translate }}</nz-form-label>
-            <nz-form-control>
-              <input nz-input
-                [(ngModel)]="formData.submitter_name"
-                name="submitter_name"
-                [placeholder]="'submitApp.placeholders.yourName' | translate" />
-            </nz-form-control>
-          </nz-form-item>
+            <nz-form-item>
+              <nz-form-label>{{ 'submitApp.fields.yourName' | translate }}</nz-form-label>
+              <nz-form-control>
+                <input nz-input
+                  [(ngModel)]="formData.submitter_name"
+                  name="submitter_name"
+                  [placeholder]="'submitApp.placeholders.yourName' | translate" />
+              </nz-form-control>
+            </nz-form-item>
 
-          <nz-form-item>
-            <nz-form-label nzRequired>{{ 'submitApp.fields.yourEmail' | translate }}</nz-form-label>
-            <nz-form-control>
-              <input nz-input
-                type="email"
-                [(ngModel)]="formData.submitter_email"
-                name="submitter_email"
-                [placeholder]="'submitApp.placeholders.yourEmail' | translate"
-                required />
-            </nz-form-control>
-          </nz-form-item>
+            <nz-form-item>
+              <nz-form-label nzRequired>{{ 'submitApp.fields.yourEmail' | translate }}</nz-form-label>
+              <nz-form-control>
+                <input nz-input
+                  type="email"
+                  [(ngModel)]="formData.submitter_email"
+                  name="submitter_email"
+                  [placeholder]="'submitApp.placeholders.yourEmail' | translate"
+                  required />
+              </nz-form-control>
+            </nz-form-item>
 
-          <nz-form-item>
-            <nz-form-label>{{ 'submitApp.fields.phone' | translate }}</nz-form-label>
-            <nz-form-control>
-              <input nz-input
-                [(ngModel)]="formData.submitter_phone"
-                name="submitter_phone"
-                [placeholder]="'submitApp.placeholders.phone' | translate" />
-            </nz-form-control>
-          </nz-form-item>
+            <nz-form-item>
+              <nz-form-label>{{ 'submitApp.fields.phone' | translate }}</nz-form-label>
+              <nz-form-control>
+                <input nz-input
+                  [(ngModel)]="formData.submitter_phone"
+                  name="submitter_phone"
+                  [placeholder]="'submitApp.placeholders.phone' | translate" />
+              </nz-form-control>
+            </nz-form-item>
 
-          <nz-form-item>
-            <nz-form-label>{{ 'submitApp.fields.organization' | translate }}</nz-form-label>
-            <nz-form-control>
-              <input nz-input
-                [(ngModel)]="formData.submitter_organization"
-                name="submitter_organization"
-                [placeholder]="'submitApp.placeholders.organization' | translate" />
-            </nz-form-control>
-          </nz-form-item>
+            <nz-form-item>
+              <nz-form-label>{{ 'submitApp.fields.organization' | translate }}</nz-form-label>
+              <nz-form-control>
+                <input nz-input
+                  [(ngModel)]="formData.submitter_organization"
+                  name="submitter_organization"
+                  [placeholder]="'submitApp.placeholders.organization' | translate" />
+              </nz-form-control>
+            </nz-form-item>
 
-          <div class="checkbox-item">
-            <label nz-checkbox [(ngModel)]="formData.is_developer" name="is_developer">
-              {{ 'submitApp.fields.isDeveloper' | translate }}
+            <div class="checkbox-item">
+              <label nz-checkbox [(ngModel)]="formData.is_developer" name="is_developer">
+                {{ 'submitApp.fields.isDeveloper' | translate }}
+              </label>
+            </div>
+          </nz-card>
+
+          <!-- Step 1: App Name -->
+          <nz-card class="form-section">
+            <h2 class="section-title">
+              <span nz-icon nzType="mobile" nzTheme="outline"></span>
+              {{ 'submitApp.sections.appDetails' | translate }}
+            </h2>
+
+            <nz-form-item>
+              <nz-form-label nzRequired>{{ 'submitApp.fields.appNameEn' | translate }}</nz-form-label>
+              <nz-form-control [nzErrorTip]="'submitApp.validation.appNameRequired' | translate">
+                <input nz-input
+                  #appNameEnCtrl="ngModel"
+                  [(ngModel)]="formData.app_name_en"
+                  name="app_name_en"
+                  [placeholder]="'submitApp.placeholders.appNameEn' | translate"
+                  required />
+              </nz-form-control>
+            </nz-form-item>
+
+            <nz-form-item>
+              <nz-form-label>{{ 'submitApp.fields.appNameAr' | translate }}</nz-form-label>
+              <nz-form-control>
+                <input nz-input
+                  dir="rtl"
+                  [(ngModel)]="formData.app_name_ar"
+                  name="app_name_ar"
+                  [placeholder]="'submitApp.placeholders.appNameAr' | translate" />
+              </nz-form-control>
+            </nz-form-item>
+          </nz-card>
+
+          <!-- Step 1: Store Links -->
+          <nz-card class="form-section">
+            <h2 class="section-title">
+              <span nz-icon nzType="link" nzTheme="outline"></span>
+              {{ 'submitApp.sections.storeLinks' | translate }}
+            </h2>
+
+            @if (!hasStoreLink && (submitForm.submitted || googlePlayCtrl.touched || appStoreCtrl.touched || appGalleryCtrl.touched)) {
+              <nz-alert
+                nzType="warning"
+                [nzMessage]="'submitApp.validation.storeLink' | translate"
+                nzShowIcon
+                class="store-link-warning">
+              </nz-alert>
+            }
+
+            <nz-form-item>
+              <nz-form-label>{{ 'submitApp.fields.googlePlay' | translate }}</nz-form-label>
+              <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
+                <input nz-input
+                  #googlePlayCtrl="ngModel"
+                  [(ngModel)]="formData.google_play_link"
+                  name="google_play_link"
+                  [pattern]="storeLinkPattern"
+                  [placeholder]="'submitApp.placeholders.googlePlay' | translate" />
+              </nz-form-control>
+            </nz-form-item>
+
+            <nz-form-item>
+              <nz-form-label>{{ 'submitApp.fields.appStore' | translate }}</nz-form-label>
+              <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
+                <input nz-input
+                  #appStoreCtrl="ngModel"
+                  [(ngModel)]="formData.app_store_link"
+                  name="app_store_link"
+                  [pattern]="storeLinkPattern"
+                  [placeholder]="'submitApp.placeholders.appStore' | translate" />
+              </nz-form-control>
+            </nz-form-item>
+
+            <nz-form-item>
+              <nz-form-label>{{ 'submitApp.fields.appGallery' | translate }}</nz-form-label>
+              <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
+                <input nz-input
+                  #appGalleryCtrl="ngModel"
+                  [(ngModel)]="formData.app_gallery_link"
+                  name="app_gallery_link"
+                  [pattern]="storeLinkPattern"
+                  [placeholder]="'submitApp.placeholders.appGallery' | translate" />
+              </nz-form-control>
+            </nz-form-item>
+
+            <nz-form-item>
+              <nz-form-label>{{ 'submitApp.fields.website' | translate }}</nz-form-label>
+              <nz-form-control>
+                <input nz-input
+                  [(ngModel)]="formData.website_link"
+                  name="website_link"
+                  [placeholder]="'submitApp.placeholders.website' | translate" />
+              </nz-form-control>
+            </nz-form-item>
+          </nz-card>
+
+          <!-- Content Confirmation -->
+          <nz-card class="form-section confirmation-section">
+            <label nz-checkbox [(ngModel)]="formData.content_confirmation" name="content_confirmation">
+              <span class="confirmation-text">
+                {{ 'submitApp.fields.contentConfirmation' | translate }}
+              </span>
             </label>
+          </nz-card>
+
+          <div class="step-nav">
+            <span></span>
+            <button nz-button
+              nzType="primary"
+              nzSize="large"
+              [nzLoading]="isSubmitting"
+              [disabled]="!isFormValid()">
+              <span nz-icon nzType="send" nzTheme="outline"></span>
+              {{ 'submitApp.submitButton' | translate }}
+            </button>
           </div>
-        </nz-card>
+        }
 
-        <!-- Step 1: App Name -->
-        <nz-card class="form-section">
-          <h2 class="section-title">
-            <span nz-icon nzType="mobile" nzTheme="outline"></span>
-            {{ 'submitApp.sections.appDetails' | translate }}
-          </h2>
+      </form>
+    </nz-spin>
 
-          <nz-form-item>
-            <nz-form-label nzRequired>{{ 'submitApp.fields.appNameEn' | translate }}</nz-form-label>
-            <nz-form-control [nzErrorTip]="'submitApp.validation.appNameRequired' | translate">
-              <input nz-input
-                #appNameEnCtrl="ngModel"
-                [(ngModel)]="formData.app_name_en"
-                name="app_name_en"
-                [placeholder]="'submitApp.placeholders.appNameEn' | translate"
-                required />
-            </nz-form-control>
-          </nz-form-item>
-
-          <nz-form-item>
-            <nz-form-label>{{ 'submitApp.fields.appNameAr' | translate }}</nz-form-label>
-            <nz-form-control>
-              <input nz-input
-                dir="rtl"
-                [(ngModel)]="formData.app_name_ar"
-                name="app_name_ar"
-                [placeholder]="'submitApp.placeholders.appNameAr' | translate" />
-            </nz-form-control>
-          </nz-form-item>
-        </nz-card>
-
-        <!-- Step 1: Store Links -->
-        <nz-card class="form-section">
-          <h2 class="section-title">
-            <span nz-icon nzType="link" nzTheme="outline"></span>
-            {{ 'submitApp.sections.storeLinks' | translate }}
-          </h2>
-
-          @if (!hasStoreLink && (submitForm.submitted || googlePlayCtrl.touched || appStoreCtrl.touched || appGalleryCtrl.touched)) {
-            <nz-alert
-              nzType="warning"
-              [nzMessage]="'submitApp.validation.storeLink' | translate"
-              nzShowIcon
-              class="store-link-warning">
-            </nz-alert>
-          }
-
-          <nz-form-item>
-            <nz-form-label>{{ 'submitApp.fields.googlePlay' | translate }}</nz-form-label>
-            <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
-              <input nz-input
-                #googlePlayCtrl="ngModel"
-                [(ngModel)]="formData.google_play_link"
-                name="google_play_link"
-                [pattern]="storeLinkPattern"
-                [placeholder]="'submitApp.placeholders.googlePlay' | translate" />
-            </nz-form-control>
-          </nz-form-item>
-
-          <nz-form-item>
-            <nz-form-label>{{ 'submitApp.fields.appStore' | translate }}</nz-form-label>
-            <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
-              <input nz-input
-                #appStoreCtrl="ngModel"
-                [(ngModel)]="formData.app_store_link"
-                name="app_store_link"
-                [pattern]="storeLinkPattern"
-                [placeholder]="'submitApp.placeholders.appStore' | translate" />
-            </nz-form-control>
-          </nz-form-item>
-
-          <nz-form-item>
-            <nz-form-label>{{ 'submitApp.fields.appGallery' | translate }}</nz-form-label>
-            <nz-form-control [nzErrorTip]="'submitApp.validation.invalidStoreLink' | translate">
-              <input nz-input
-                #appGalleryCtrl="ngModel"
-                [(ngModel)]="formData.app_gallery_link"
-                name="app_gallery_link"
-                [pattern]="storeLinkPattern"
-                [placeholder]="'submitApp.placeholders.appGallery' | translate" />
-            </nz-form-control>
-          </nz-form-item>
-
-          <nz-form-item>
-            <nz-form-label>{{ 'submitApp.fields.website' | translate }}</nz-form-label>
-            <nz-form-control>
-              <input nz-input
-                [(ngModel)]="formData.website_link"
-                name="website_link"
-                [placeholder]="'submitApp.placeholders.website' | translate" />
-            </nz-form-control>
-          </nz-form-item>
-        </nz-card>
-
-        <!-- Content Confirmation -->
-        <nz-card class="form-section confirmation-section">
-          <label nz-checkbox [(ngModel)]="formData.content_confirmation" name="content_confirmation">
-            <span class="confirmation-text">
-              {{ 'submitApp.fields.contentConfirmation' | translate }}
-            </span>
-          </label>
-        </nz-card>
-
-        <div class="step-nav">
-          <span></span>
-          <button nz-button
-            nzType="primary"
-            nzSize="large"
-            [nzLoading]="isSubmitting"
-            [disabled]="!isFormValid()">
-            <span nz-icon nzType="send" nzTheme="outline"></span>
-            {{ 'submitApp.submitButton' | translate }}
-          </button>
+    <!-- Live preview card -->
+    <aside class="preview-card">
+      <h4 class="preview-label">{{ 'submitApp.preview.label' | translate }}</h4>
+      <div class="preview-app">
+        <div class="preview-icon">
+          <span nz-icon nzType="mobile" nzTheme="outline"></span>
         </div>
-      }
-
-    </form>
-  </nz-spin>
-
-  <!-- Live preview card -->
-  <aside class="preview-card">
-    <h4 class="preview-label">{{ 'submitApp.preview.label' | translate }}</h4>
-    <div class="preview-app">
-      <div class="preview-icon">
-        <span nz-icon nzType="mobile" nzTheme="outline"></span>
-      </div>
-      <div>
-        <div class="preview-name">
-          {{ formData.app_name_en || ('submitApp.preview.placeholderName' | translate) }}
+        <div>
+          <div class="preview-name">
+            {{ formData.app_name_en || ('submitApp.preview.placeholderName' | translate) }}
+          </div>
+          <div class="preview-status">{{ 'submitApp.preview.pendingReview' | translate }}</div>
         </div>
-        <div class="preview-status">{{ 'submitApp.preview.pendingReview' | translate }}</div>
       </div>
+      <div class="preview-tags">
+        <span class="tag" [class.tag-done]="hasStoreLink">
+          <span nz-icon [nzType]="hasStoreLink ? 'check-circle' : 'link'" nzTheme="outline"></span>
+          {{ (hasStoreLink ? 'submitApp.preview.storeLinkAdded' : 'submitApp.preview.storeLinkMissing') | translate }}
+        </span>
+        <span class="tag" [class.tag-done]="formData.submitter_email">
+          <span nz-icon [nzType]="formData.submitter_email ? 'check-circle' : 'mail'" nzTheme="outline"></span>
+          {{ (formData.submitter_email ? 'submitApp.preview.emailAdded' : 'submitApp.preview.emailMissing') | translate }}
+        </span>
+      </div>
+      <div class="preview-ready" [class.ready]="isFormValid()">
+        <span nz-icon [nzType]="isFormValid() ? 'check-circle' : 'info-circle'" nzTheme="outline"></span>
+        {{ (isFormValid() ? 'submitApp.preview.readyToSubmit' : 'submitApp.preview.notReadyYet') | translate }}
+      </div>
+    </aside>
     </div>
-    <div class="preview-tags">
-      <span class="tag" [class.tag-done]="hasStoreLink">
-        <span nz-icon [nzType]="hasStoreLink ? 'check-circle' : 'link'" nzTheme="outline"></span>
-        {{ (hasStoreLink ? 'submitApp.preview.storeLinkAdded' : 'submitApp.preview.storeLinkMissing') | translate }}
-      </span>
-      <span class="tag" [class.tag-done]="formData.submitter_email">
-        <span nz-icon [nzType]="formData.submitter_email ? 'check-circle' : 'mail'" nzTheme="outline"></span>
-        {{ (formData.submitter_email ? 'submitApp.preview.emailAdded' : 'submitApp.preview.emailMissing') | translate }}
-      </span>
-    </div>
-    <div class="preview-ready" [class.ready]="isFormValid()">
-      <span nz-icon [nzType]="isFormValid() ? 'check-circle' : 'info-circle'" nzTheme="outline"></span>
-      {{ (isFormValid() ? 'submitApp.preview.readyToSubmit' : 'submitApp.preview.notReadyYet') | translate }}
-    </div>
-  </aside>
   </div>
 </div>

--- a/src/app/pages/submit-app/submit-app.component.scss
+++ b/src/app/pages/submit-app/submit-app.component.scss
@@ -1,82 +1,209 @@
-.submit-app-container {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 16px;
+// ============================================
+// SUBMIT APP PAGE - matches about-us / contact-us design system
+// ============================================
+
+// Color variables (shared with about-us / contact-us)
+$color-ellipse-large: #12bcac;
+$color-ellipse-medium: #15a295;
+$color-ellipse-small: #186861;
+$color-text-primary: #1a1a1a;
+$color-text-secondary: #666666;
+$color-card-bg: #ffffff;
+$color-card-border: #e8e8e8;
+
+// Gold ellipses
+$color-ellipse2-large: #f5eedb;
+$color-ellipse2-medium: #faaf41;
+$color-ellipse2-small: #faaf41;
+
+// Dark mode
+$dark-ellipse-large: #0d8a7d;
+$dark-ellipse-medium: #107a6e;
+$dark-ellipse-small: #bad2d0;
+$dark-text-primary: #f0f0f0;
+$dark-text-secondary: #b3b3b3;
+$dark-card-bg: #2a2a2a;
+$dark-card-border: #3a3a3a;
+$dark-section-bg: #1f1f1f;
+$dark-ellipse2-large: #3d3626;
+$dark-ellipse2-medium: #b87a2e;
+$dark-ellipse2-small: #b87a2e;
+
+// Spacing
+$spacing-xs: 8px;
+$spacing-sm: 16px;
+$spacing-md: 24px;
+$spacing-lg: 32px;
+$spacing-xl: 48px;
+
+// ============================================
+// BASE
+// ============================================
+.submit-app-page {
+  position: relative;
+  min-height: calc(77vh - 64px);
+  font-family: "Expo Arabic", sans-serif;
+  background: #ffffff;
+  overflow-x: hidden;
 }
 
-.hero-card {
-  position: relative;
+// ============================================
+// BACKGROUND ELLIPSES
+// ============================================
+.page-background-left {
+  position: fixed;
+  inset: 0;
   overflow: hidden;
-  text-align: center;
-  margin-bottom: 20px;
-  padding: 120px 16px 32px;
-  background: var(--card-bg, #fff);
-  border-radius: 16px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  pointer-events: none;
+  z-index: 0;
 
-  .hero-content {
-    position: relative;
-    z-index: 1;
-  }
-
-  .hero-blob {
+  &::before {
+    content: "";
     position: absolute;
-    width: 220px;
-    height: 220px;
+    width: 800px;
+    height: 990px;
+    left: -686px;
+    top: 100px;
+    background: $color-ellipse-large;
+    filter: blur(1500px);
+    transform: rotate(30deg);
     border-radius: 50%;
-    filter: blur(60px);
-    opacity: 0.2;
-    pointer-events: none;
   }
 
-  .hero-blob-teal {
-    top: -80px;
-    inset-inline-end: -60px;
-    background: #12bcac;
+  &::after {
+    content: "";
+    position: absolute;
+    width: 584px;
+    height: 583px;
+    left: -428px;
+    top: 300px;
+    background: $color-ellipse-large;
+    opacity: 0.4;
+    transform: rotate(30deg);
+    border-radius: 50%;
+    filter: blur(200px);
   }
 
-  .hero-blob-gold {
-    bottom: -90px;
-    inset-inline-start: -50px;
-    background: #faaf41;
+  .ellipse-small {
+    position: absolute;
+    width: 302px;
+    height: 301px;
+    left: -235px;
+    top: 500px;
+    background: $color-ellipse-small;
+    transform: rotate(30deg);
+    border-radius: 50%;
+    filter: blur(50px);
+  }
+}
+
+.page-background-right {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+
+  &::before {
+    content: "";
+    position: absolute;
+    width: 990px;
+    height: 990px;
+    right: -700px;
+    top: -160px;
+    background: $color-ellipse2-large;
+    filter: blur(200px);
+    transform: rotate(-135deg);
+    border-radius: 50%;
+    opacity: 0.78;
   }
 
-  .hero-tag {
-    display: inline-block;
-    padding: 4px 14px;
-    margin-bottom: 12px;
-    border-radius: 9999px;
-    font-size: 12px;
-    font-weight: 600;
-    background: rgba(160, 83, 59, 0.08);
-    color: var(--primary-color, #a0533b);
+  &::after {
+    content: "";
+    position: absolute;
+    width: 584px;
+    height: 583px;
+    right: -400px;
+    top: 101px;
+    background: $color-ellipse2-medium;
+    opacity: 0.4;
+    filter: blur(80px);
+    transform: rotate(-135deg);
+    border-radius: 50%;
   }
+
+  .ellipse-small {
+    position: absolute;
+    width: 302px;
+    height: 301px;
+    right: -150px;
+    top: 301px;
+    background: $color-ellipse2-small;
+    filter: blur(40px);
+    transform: rotate(-135deg);
+    border-radius: 50%;
+  }
+}
+
+// ============================================
+// HERO SECTION
+// ============================================
+.hero-section {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 120px $spacing-md 40px;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  max-width: 800px;
+  padding: 0 $spacing-md;
 
   h1 {
-    margin: 0 0 8px 0;
-    font-size: 24px;
-    color: var(--primary-color, #a0533b);
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: $color-text-primary;
+    margin-bottom: $spacing-md;
+    line-height: 1.3;
   }
 
-  p {
-    margin: 0;
-    color: var(--text-secondary, #666);
-    font-size: 14px;
+  .description {
+    font-size: 1.1rem;
+    color: $color-text-secondary;
+    line-height: 1.8;
+    max-width: 700px;
+    margin: 0 auto;
   }
+}
+
+// ============================================
+// CONTENT CONTAINER
+// ============================================
+.content-container {
+  position: relative;
+  z-index: 1;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 $spacing-md $spacing-xl;
 }
 
 .track-link-banner {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 10px 16px;
-  margin-bottom: 16px;
-  background: var(--info-bg, #e6f7ff);
-  border: 1px solid var(--info-border, #91d5ff);
-  border-radius: 6px;
+  gap: $spacing-xs;
+  padding: 10px $spacing-sm;
+  margin-bottom: $spacing-sm;
+  background: rgba(160, 83, 59, 0.06);
+  border: 1px solid rgba(160, 83, 59, 0.2);
+  border-radius: 20px;
   font-size: 13px;
-  color: var(--text-color, #333);
+  color: $color-text-primary;
   flex-wrap: wrap;
 
   span[nz-icon] {
@@ -100,7 +227,7 @@
 .form-layout {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 20px;
+  gap: $spacing-md;
   align-items: start;
 
   @media (min-width: 768px) {
@@ -112,33 +239,35 @@
   min-width: 0;
 }
 
+// ============================================
+// PREVIEW CARD
+// ============================================
 .preview-card {
-  background: var(--card-bg, #fff);
-  border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 10px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  padding: 20px;
+  background: $color-card-bg;
+  border: 1px solid $color-card-border;
+  border-radius: 12px;
+  padding: $spacing-md;
 
   @media (min-width: 768px) {
     position: sticky;
-    top: 20px;
+    top: $spacing-md;
   }
 }
 
 .preview-label {
-  margin: 0 0 12px 0;
+  margin: 0 0 $spacing-sm 0;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--text-secondary, #999);
+  color: $color-text-secondary;
 }
 
 .preview-app {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 14px;
+  gap: $spacing-sm;
+  margin-bottom: $spacing-sm;
 }
 
 .preview-icon {
@@ -149,7 +278,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--surface-color, #f8f9fa);
+  background: rgba(160, 83, 59, 0.08);
   color: var(--primary-color, #a0533b);
   font-size: 18px;
 }
@@ -157,20 +286,20 @@
 .preview-name {
   font-size: 14px;
   font-weight: 600;
-  color: var(--text-color, #333);
+  color: $color-text-primary;
   word-break: break-word;
 }
 
 .preview-status {
   font-size: 12px;
-  color: var(--text-secondary, #999);
+  color: $color-text-secondary;
 }
 
 .preview-tags {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-bottom: 14px;
+  gap: $spacing-xs;
+  margin-bottom: $spacing-sm;
 }
 
 .preview-tags .tag,
@@ -181,8 +310,8 @@
   font-size: 12px;
   padding: 6px 10px;
   border-radius: 9999px;
-  background: var(--surface-color, #f8f9fa);
-  color: var(--text-secondary, #999);
+  background: rgba(0, 0, 0, 0.04);
+  color: $color-text-secondary;
   width: fit-content;
 }
 
@@ -202,26 +331,30 @@
   }
 }
 
+// ============================================
+// FORM SECTIONS (feature-card style)
+// ============================================
 .form-section {
-  margin-bottom: 16px;
-  border-radius: 10px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  background: $color-card-bg;
+  border: 1px solid $color-card-border;
+  border-radius: 12px;
+  margin-bottom: $spacing-sm;
 
   ::ng-deep .ant-card-body {
-    padding: 16px;
+    padding: $spacing-md;
   }
 }
 
 .section-title {
-  margin: 0 0 16px 0;
+  margin: 0 0 $spacing-sm 0;
   padding-bottom: 10px;
-  border-bottom: 1px solid var(--border-color, #eee);
+  border-bottom: 1px solid $color-card-border;
   font-size: 16px;
   font-weight: 600;
-  color: var(--text-color, #333);
+  color: $color-text-primary;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: $spacing-xs;
 
   [nz-icon] {
     color: var(--primary-color, #a0533b);
@@ -243,7 +376,7 @@
   padding: 0 0 6px 0;
   font-weight: 500;
   font-size: 13px;
-  color: var(--text-color, #333);
+  color: $color-text-primary;
   text-align: start;
   flex: none;
   width: 100%;
@@ -281,13 +414,13 @@
 }
 
 .checkbox-item {
-  margin-top: 8px;
+  margin-top: $spacing-xs;
 }
 
 .char-count {
   font-size: 11px;
   font-weight: normal;
-  color: var(--text-secondary, #999);
+  color: $color-text-secondary;
   margin-left: 6px;
 
   &.warning {
@@ -297,7 +430,7 @@
 
 .field-hint {
   font-size: 11px;
-  color: var(--text-secondary, #999);
+  color: $color-text-secondary;
   margin-top: 4px;
 }
 
@@ -307,12 +440,12 @@
   margin-top: 6px;
 }
 
-// Step wizard
+// Dormant step-wizard styles (unused while currentStep is always 0, kept for potential reuse)
 .step-indicator {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: $spacing-xs;
   margin-bottom: 12px;
 }
 
@@ -325,9 +458,9 @@
   justify-content: center;
   font-size: 12px;
   font-weight: 700;
-  background: var(--surface-color, #f8f9fa);
-  color: var(--text-secondary, #999);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: rgba(0, 0, 0, 0.04);
+  color: $color-text-secondary;
+  border: 1px solid $color-card-border;
   transition: all 0.2s ease;
 
   &.active {
@@ -346,7 +479,7 @@
 .step-line {
   width: 40px;
   height: 2px;
-  background: var(--border-color, #dee2e6);
+  background: $color-card-border;
 
   &.done {
     background: var(--primary-color, #a0533b);
@@ -356,10 +489,10 @@
 .step-labels {
   display: flex;
   justify-content: center;
-  gap: 24px;
-  margin-bottom: 20px;
+  gap: $spacing-md;
+  margin-bottom: $spacing-sm;
   font-size: 12px;
-  color: var(--text-secondary, #999);
+  color: $color-text-secondary;
 
   span.active {
     color: var(--primary-color, #a0533b);
@@ -371,8 +504,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 16px 0 32px;
+  gap: $spacing-sm;
+  padding: $spacing-sm 0 $spacing-lg;
 
   button {
     min-width: 140px;
@@ -401,10 +534,11 @@
 }
 
 .confirmation-section {
-  background: #fdf2f0;
+  background: rgba(160, 83, 59, 0.06);
+  border-color: rgba(160, 83, 59, 0.2);
 
   ::ng-deep .ant-card-body {
-    padding: 14px 16px;
+    padding: 14px $spacing-sm;
   }
 }
 
@@ -413,10 +547,18 @@
   line-height: 1.5;
 }
 
-// RTL support
+// ============================================
+// LTR / RTL
+// ============================================
+:host-context([dir="ltr"]) {
+  .section-title {
+    text-align: start;
+  }
+}
+
 [dir="rtl"] {
   .section-title [nz-icon] {
-    margin-left: 8px;
+    margin-left: $spacing-xs;
     margin-right: 0;
   }
 
@@ -424,86 +566,219 @@
     margin-left: 0;
     margin-right: 6px;
   }
+
+  .page-background-left {
+    &::before {
+      left: auto;
+      right: -686px;
+    }
+
+    &::after {
+      left: auto;
+      right: -428px;
+    }
+
+    .ellipse-small {
+      left: auto;
+      right: -235px;
+    }
+  }
+
+  .page-background-right {
+    &::before {
+      right: auto;
+      left: -700px;
+      transform: rotate(135deg);
+    }
+
+    &::after {
+      right: auto;
+      left: -400px;
+      transform: rotate(135deg);
+    }
+
+    .ellipse-small {
+      right: auto;
+      left: -150px;
+      transform: rotate(135deg);
+    }
+  }
 }
 
-// Dark theme
+// ============================================
+// DARK MODE
+// ============================================
 :host-context(.dark-theme) {
-  .hero-card {
-    background: var(--card-bg, #1f1f1f);
+  .submit-app-page {
+    background: $dark-section-bg;
   }
 
-  .preview-card {
-    background: var(--card-bg, #1f1f1f);
-    border-color: var(--border-color, #333);
+  .page-background-left {
+    &::before {
+      background: $dark-ellipse-large;
+    }
+    &::after {
+      background: $dark-ellipse-medium;
+    }
+    .ellipse-small {
+      background: $dark-ellipse-small;
+    }
   }
 
-  .preview-icon,
-  .preview-tags .tag,
-  .preview-ready {
-    background: var(--surface-color, #2a2a2a);
+  .page-background-right {
+    &::before {
+      background: $dark-ellipse2-large;
+    }
+    &::after {
+      background: $dark-ellipse2-medium;
+    }
+    .ellipse-small {
+      background: $dark-ellipse2-small;
+    }
   }
 
-  .step-dot {
-    background: var(--surface-color, #2a2a2a);
-    border-color: var(--border-color, #444);
+  .hero-content {
+    h1 {
+      color: $dark-text-primary;
+    }
+    .description {
+      color: $dark-text-secondary;
+    }
   }
 
   .track-link-banner {
     background: rgba(160, 83, 59, 0.15);
     border-color: rgba(160, 83, 59, 0.3);
-    color: var(--text-color, #e0e0e0);
+    color: $dark-text-primary;
   }
 
-  .form-section {
-    background: var(--card-bg, #1f1f1f);
-    border: 1px solid var(--border-color, #333);
-
-    ::ng-deep .ant-card {
-      background: transparent;
-    }
+  .form-section,
+  .preview-card {
+    background: $dark-card-bg;
+    border-color: $dark-card-border;
   }
 
   .section-title {
-    border-bottom-color: var(--border-color, #333);
+    color: $dark-text-primary;
+    border-bottom-color: $dark-card-border;
+  }
+
+  .preview-name,
+  .preview-label,
+  .preview-status {
+    color: $dark-text-secondary;
+  }
+
+  .preview-name {
+    color: $dark-text-primary;
   }
 
   .confirmation-section {
     background: rgba(160, 83, 59, 0.15);
   }
 
+  .step-dot {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: $dark-card-border;
+  }
+
   ::ng-deep nz-form-label {
-    color: var(--text-color, #e0e0e0);
+    color: $dark-text-primary;
   }
 }
 
-// Responsive
-@media (max-width: 480px) {
-  .submit-app-container {
-    padding: 12px;
+// ============================================
+// RESPONSIVE
+// ============================================
+@media (max-width: 1024px) {
+  .page-background-left {
+    &::before {
+      width: 700px;
+      height: 700px;
+      left: -500px;
+      filter: blur(10px);
+    }
+
+    &::after {
+      width: 450px;
+      height: 450px;
+      left: -350px;
+    }
+
+    .ellipse-small {
+      width: 220px;
+      height: 220px;
+      left: -180px;
+    }
   }
 
-  .hero-card {
-    padding: 80px 12px 20px;
+  .page-background-right {
+    &::before {
+      width: 700px;
+      height: 700px;
+      right: -500px;
+      filter: blur(150px);
+    }
+
+    &::after {
+      width: 450px;
+      height: 450px;
+      right: -300px;
+      filter: blur(60px);
+    }
+
+    .ellipse-small {
+      width: 220px;
+      height: 220px;
+      right: -100px;
+      filter: blur(30px);
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .hero-section {
+    margin-top: 50px;
+    padding: 80px $spacing-sm $spacing-md;
+  }
+
+  .hero-content {
+    padding: 0 $spacing-xs;
 
     h1 {
-      font-size: 20px;
+      font-size: 1.75rem;
+      margin-bottom: $spacing-sm;
     }
 
-    p {
-      font-size: 13px;
+    .description {
+      font-size: 0.9rem;
+      line-height: 1.7;
     }
   }
 
+  .content-container {
+    padding: 0 $spacing-sm $spacing-lg;
+  }
+
+  .page-background-left,
+  .page-background-right {
+    .ellipse-small {
+      display: none;
+    }
+  }
+}
+
+@media (max-width: 480px) {
   .track-link-banner {
     font-size: 12px;
-    padding: 8px 12px;
+    padding: 8px $spacing-sm;
   }
 
   .form-section {
-    margin-bottom: 12px;
+    margin-bottom: $spacing-xs;
 
     ::ng-deep .ant-card-body {
-      padding: 12px;
+      padding: $spacing-sm;
     }
   }
 


### PR DESCRIPTION
## Summary
- Redesigned the submit-app page to match the site's actual `about-us`/`contact-us` design system instead of a custom look: fixed full-page teal/gold blurred-ellipse backgrounds, unboxed hero-section (same top-padding convention to clear the floating nav), and reskinned form-section cards to match the site's `feature-card` style (white bg, `#e8e8e8` border, 12px radius), using the same SCSS variables/spacing scale/dark-mode palette as those two pages.
- Fixed `contact-us`'s "Request Form" card - it linked to an external Google Form; now uses `routerLink` to `/{lang}/submit-app` instead.

## Test plan
- [x] `tsc-check` - only the pre-existing unrelated `functions/[[path]].ts` error
- [x] Visual comparison against `contact-us` in light/dark theme and mobile RTL (Arabic) - background gradients, hero typography, and layout match
- [x] Full local run: real Postgres + Django dev server + Angular dev server, real end-to-end submission (201 + tracking-ID success modal) to confirm the structural changes (fixed backgrounds, z-index layering) didn't break the click-to-submit path
- [x] Confirmed contact-us "Request Form" card now links to `/en/submit-app` (routerLink), not the external form