### PR TITLE
Submit App - Clarify disabled button style

### DIFF
--- a/src/app/pages/submit-app/submit-app.component.scss
+++ b/src/app/pages/submit-app/submit-app.component.scss
@@ -524,7 +524,11 @@ $spacing-xl: 48px;
     }
 
     &:disabled {
-      opacity: 0.6;
+      opacity: 1;
+      background-color: #d1d1d6;
+      border-color: #d1d1d6;
+      color: #8a8a8e;
+      cursor: not-allowed;
     }
   }
 }
@@ -611,6 +615,12 @@ $spacing-xl: 48px;
 :host-context(.dark-theme) {
   .submit-app-page {
     background: $dark-section-bg;
+  }
+
+  .step-nav button[nztype="primary"]:disabled {
+    background-color: #4a4a4a;
+    border-color: #4a4a4a;
+    color: $dark-text-secondary;
   }
 
   .page-background-left {


### PR DESCRIPTION
## Summary
- Disabled submit button used `opacity: 0.6` only, brand color bled through, looked clickable.
- Now solid gray background, muted text, `cursor: not-allowed`, plus dark-theme override.

## Test plan
- [ ] `/ar/submit-app`, confirm button gray + not-allowed cursor when form invalid
- [ ] Fill required fields, confirm button turns primary color and clickable
- [ ] Toggle dark mode, confirm disabled state still legible