### PR TITLE
feat: add server-driven search with URL filters and pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -498,7 +498,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.15.tgz",
       "integrity": "sha512-ikyKfhkxoqQA6JcBN0B9RaN6369sM1XYX81Id0lI58dmWCe7gYfrTp8ejqxxKftl514psQO3pkW8Gn1nJ131Gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -713,7 +712,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.15.tgz",
       "integrity": "sha512-k4mCXWRFiOHK3bUKfWkRQQ8KBPxW8TAJuKLYCsSHPCpMz6u0eA1F0VlrnOkZVKWPI792fOaEAWH2Y4PTaXlUHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -730,7 +728,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.15.tgz",
       "integrity": "sha512-lMicIAFAKZXa+BCZWs3soTjNQPZZXrF/WMVDinm8dQcggNarnDj4UmXgKSyXkkyqK5SLfnLsXVzrX6ndVT6z7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -744,7 +741,6 @@
       "integrity": "sha512-8sJoxodxsfyZ8eJ5r6Bx7BCbazXYgsZ1+dE8t5u5rTQ6jNggwNtYEzkyReoD5xvP+MMtRkos3xpwq4rtFnpI6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.3",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -777,7 +773,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.15.tgz",
       "integrity": "sha512-NMbX71SlTZIY9+rh/SPhRYFJU0pMJYW7z/TBD4lqiO+b0DTOIg1k7Pg9ydJGqSjFO1Z4dQaA6TteNuF99TJCNw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -803,7 +798,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.15.tgz",
       "integrity": "sha512-gS5hQkinq52pm/7mxz4yHPCzEcmRWjtUkOVddPH0V1BW/HMni/p4Y6k2KqKBeGb9p8S5EAp6PDxDVLOPukp3mg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -822,7 +816,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.15.tgz",
       "integrity": "sha512-TxRM/wTW/oGXv/3/Iohn58yWoiYXOaeEnxSasiGNS1qhbkcKtR70xzxW6NjChBUYAixz2ERkLURkpx3pI8Q6Dw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -863,7 +856,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-20.3.15.tgz",
       "integrity": "sha512-OB3/ztCREeZ0pe2P+43Nah9Xq2Y79fN6mbsOY1JwwYxkM8ZN1WkSP11xlHHwAcoquHP7uFPhXwJqgTHBqGqkcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0",
         "xhr2": "^0.2.0"
@@ -884,7 +876,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.15.tgz",
       "integrity": "sha512-6+qgk8swGSoAu7ISSY//GatAyCP36hEvvUgvjbZgkXLLH9yUQxdo77ij05aJ5s0OyB25q/JkqS8VTY0z1yE9NQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -903,7 +894,6 @@
       "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-20.3.15.tgz",
       "integrity": "sha512-HCptODPVWg30XJwSueOz2zqsJjQ1chSscTs7FyIQcfuCTTthO35Lvz2Gtct8/GNHel9QNvvVwA5jrLjsU4dt1A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -923,7 +913,6 @@
       "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-20.3.12.tgz",
       "integrity": "sha512-liIxrlozOkcx+6qkMb0rFcKjo32aRtUI/U7TQ+1KA1XZrIk97aTjHEpq0KhBMjNlOt/xwrlUARDXjS5au5kP5g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1007,7 +996,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3315,7 +3303,6 @@
       "integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.2.1",
         "@inquirer/confirm": "^5.1.14",
@@ -4611,7 +4598,6 @@
       "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-15.0.0.tgz",
       "integrity": "sha512-Am5uiuR0bOOxyoercDnAA3rJVizo4RRqJHo8N3RqJ+XfzVP/I845yEnMADykOHvM6HkVm4SZSnJBOiz0Anx5BA==",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "engines": {
         "node": "^16.13.0 || >=18.10.0"
       },
@@ -5940,7 +5926,6 @@
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
@@ -6264,7 +6249,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6330,7 +6314,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6795,7 +6778,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -9285,7 +9267,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9407,7 +9388,6 @@
       "integrity": "sha512-kdTwsyRuncDfjEs0DlRILWNvxhDG/Zij4YLO4TMJgDLW+8OzpfkdPnRgrsRuY1o+oaxJGWsps5f/RVBgGmmN0w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -9498,7 +9478,6 @@
       "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^4.0.0",
         "colorette": "^2.0.20",
@@ -11278,7 +11257,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11918,7 +11896,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11957,7 +11934,6 @@
       "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -12950,7 +12926,6 @@
       "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.14.0",
@@ -13094,8 +13069,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "3.1.0",
@@ -13139,7 +13113,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13340,7 +13313,6 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -13465,7 +13437,6 @@
       "integrity": "sha512-4JLXU0tD6OZNVqlwzm3HGEhAHufSiyv+skb7q0d2367VDMzrU1Q/ZeepvkcHH0rZie6uqEtTQQe0OEOOluH3Mg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -13545,7 +13516,6 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -14096,7 +14066,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -14115,8 +14084,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/src/app/pages/app-list/app-list.component.html
+++ b/src/app/pages/app-list/app-list.component.html
@@ -28,14 +28,14 @@
         <button
           class="search-tab"
           [class.active]="searchType === 'traditional'"
-          (click)="searchType = 'traditional'"
+          (click)="onSearchTypeChange('traditional')"
         >
           {{ "appList.search.traditional" | translate }}
         </button>
         <button
           class="search-tab"
           [class.active]="searchType === 'smart'"
-          (click)="searchType = 'smart'"
+          (click)="onSearchTypeChange('smart')"
         >
           {{ "appList.search.smart" | translate }}
         </button>
@@ -164,6 +164,30 @@
         }
       </div>
     </div>
+
+    <!-- Platform Filter -->
+    <div class="platform-filter-wrapper">
+      <div class="platform-filter-card">
+        <label class="platform-filter-label" for="platform-select">
+          {{ "appList.filters.platform.label" | translate }}
+        </label>
+        <nz-select
+          id="platform-select"
+          class="platform-select"
+          nzDropdownClassName="app-list-platform-dropdown"
+          [ngModel]="selectedPlatform"
+          (ngModelChange)="onPlatformChange($event)"
+          [nzDisabled]="searchType === 'smart'"
+        >
+          @for (platform of platformFilters; track platform) {
+            <nz-option
+              [nzValue]="platform"
+              [nzLabel]="('appList.filters.platform.' + platform) | translate"
+            ></nz-option>
+          }
+        </nz-select>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -222,7 +246,7 @@
   }
 
   <!-- Shimmer Loading State -->
-  @if ((isLoading || isSmartSearching) && filteredApps.length === 0) {
+  @if ((isLoading || isServerFetching || isSmartSearching) && filteredApps.length === 0) {
     <div class="apps-grid">
       @for (item of [1, 2, 3, 4, 5, 6]; track item) {
         <div class="app-card shimmer-card">
@@ -246,16 +270,16 @@
 
   <!-- Search Results Header -->
   @if (
-    searchExecuted && searchQuery.trim() && !isSmartSearching && !isLoading
+    searchExecuted && searchQuery.trim() && !isSmartSearching && !isLoading && !isServerFetching
   ) {
     <div class="search-results-header">
       <h2 class="search-results-title">
         {{ "appList.search.resultsFor" | translate }} "{{ searchQuery }}"
       </h2>
       <span class="search-results-count">
-        {{ filteredApps.length }}
+        {{ getResultCount() }}
         {{
-          filteredApps.length === 1
+          getResultCount() === 1
             ? ("appList.search.result" | translate)
             : ("appList.search.results" | translate)
         }}
@@ -504,13 +528,48 @@
       }
     </div>
 
-    <!-- Loading More Indicator for Infinite Scroll -->
-    @if (isLoadingMore && filteredApps.length > 0 && !isSmartSearching) {
+    <!-- Loading More Indicator for Infinite Scroll (home browse only) -->
+    @if (isLoadingMore && filteredApps.length > 0 && !isSmartSearching && !isServerDrivenMode()) {
       <div style="text-align: center; margin: 24px 0">
         <nz-spin nzSimple></nz-spin>
         <span style="margin-left: 12px; color: var(--nz-text-color-secondary);">
           {{ currentLang === "ar" ? "جارِ تحميل المزيد..." : "Loading more..." }}
         </span>
+      </div>
+    }
+
+    <!-- Pagination for server-driven traditional search -->
+    @if (isServerDrivenMode() && filteredApps.length > 0 && getTotalPages() > 1) {
+      <div class="pagination-controls">
+        <button
+          type="button"
+          class="pagination-btn"
+          [disabled]="!serverHasPrevious || isServerFetching"
+          (click)="goToPage(currentPage - 1)"
+        >
+          {{ "appList.filters.pagination.prev" | translate }}
+        </button>
+        <span class="pagination-info">
+          {{
+            "appList.filters.pagination.page"
+              | translate
+                : { current: currentPage, total: getTotalPages() }
+          }}
+        </span>
+        <button
+          type="button"
+          class="pagination-btn"
+          [disabled]="!serverHasNext || isServerFetching"
+          (click)="goToPage(currentPage + 1)"
+        >
+          {{ "appList.filters.pagination.next" | translate }}
+        </button>
+      </div>
+    }
+
+    @if (isServerFetching && filteredApps.length > 0) {
+      <div style="text-align: center; margin: 24px 0">
+        <nz-spin nzSimple></nz-spin>
       </div>
     }
 

--- a/src/app/pages/app-list/app-list.component.scss
+++ b/src/app/pages/app-list/app-list.component.scss
@@ -668,6 +668,267 @@
 }
 
 // ============================================
+// PLATFORM FILTER
+// ============================================
+.platform-filter-wrapper {
+  display: flex;
+  justify-content: center;
+  margin-top: 12px;
+  padding: 0 4px;
+
+  @media (max-width: 768px) {
+    justify-content: flex-start;
+    padding-inline: 8px;
+  }
+
+  @media (max-width: 480px) {
+    padding-inline: 4px;
+  }
+}
+
+.platform-filter-card {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px 8px 16px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  transition: all 0.2s ease;
+
+  :host-context(.dark-theme) & {
+    background: rgba(45, 45, 45, 0.9);
+    border-color: #444;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  }
+
+  @media (max-width: 480px) {
+    width: 100%;
+    padding: 8px 10px 8px 14px;
+    border-radius: 20px;
+    gap: 10px;
+
+    .platform-select {
+      flex: 1;
+      min-width: 0;
+
+      ::ng-deep .ant-select {
+        width: 100%;
+      }
+    }
+  }
+}
+
+.platform-filter-label {
+  display: flex;
+  align-items: center;
+  height: 36px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1;
+  color: #1a1a1a;
+  white-space: nowrap;
+  margin: 0;
+  flex-shrink: 0;
+
+  :host-context(.dark-theme) & {
+    color: #e8e8e8;
+  }
+
+  @media (max-width: 480px) {
+    font-size: 13px;
+  }
+}
+
+.platform-select {
+  display: flex;
+  align-items: center;
+  min-width: 120px;
+  flex: 1;
+
+  @media (max-width: 480px) {
+    min-width: 0;
+  }
+
+  ::ng-deep {
+    &.ant-select {
+      width: auto;
+      min-width: 110px;
+      display: flex;
+      align-items: center;
+    }
+
+    &.ant-select:not(.ant-select-disabled):hover .ant-select-selector,
+    &.ant-select-focused:not(.ant-select-disabled) .ant-select-selector {
+      border-color: #4caf50 !important;
+      box-shadow: 0 2px 8px rgba(76, 175, 80, 0.12) !important;
+    }
+
+    .ant-select-selector {
+      border-radius: 20px !important;
+      min-height: 36px !important;
+      height: 36px !important;
+      padding: 0 32px 0 14px !important;
+      background: #fff !important;
+      border: 1px solid rgba(0, 0, 0, 0.15) !important;
+      box-shadow: none !important;
+      transition: all 0.2s ease;
+      display: flex !important;
+      align-items: center !important;
+    }
+
+    .ant-select-selection-wrap,
+    .ant-select-selection-search,
+    .ant-select-selection-item {
+      display: flex !important;
+      align-items: center !important;
+      height: 100% !important;
+    }
+
+    .ant-select-selection-item {
+      font-size: 13px;
+      font-weight: 400;
+      color: #1a1a1a;
+      line-height: 1.2 !important;
+      padding-inline-end: 0 !important;
+    }
+
+    .ant-select-arrow {
+      color: #666;
+      inset-inline-end: 14px !important;
+      top: 0 !important;
+      bottom: 0 !important;
+      height: 100% !important;
+      margin-top: 0 !important;
+      transform: none !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+
+      .anticon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    }
+
+    &.ant-select-disabled .ant-select-selector {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+  }
+
+  :host-context(.dark-theme) & ::ng-deep {
+    &.ant-select:not(.ant-select-disabled):hover .ant-select-selector,
+    &.ant-select-focused:not(.ant-select-disabled) .ant-select-selector {
+      border-color: #4caf50 !important;
+      box-shadow: 0 2px 8px rgba(76, 175, 80, 0.2) !important;
+    }
+
+    .ant-select-selector {
+      background: rgba(35, 35, 35, 0.95) !important;
+      border: 1px solid #666 !important;
+    }
+
+    .ant-select-selection-item {
+      color: #e0e0e0;
+    }
+
+    .ant-select-arrow {
+      color: #999;
+    }
+  }
+}
+
+// ============================================
+// PAGINATION
+// ============================================
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin: 32px 0 16px;
+  flex-wrap: wrap;
+}
+
+.pagination-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 20px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 24px;
+  font-size: 14px;
+  font-weight: 400;
+  color: #1a1a1a;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  font-family: inherit;
+
+  &:hover:not(:disabled) {
+    background: #e8f5e9;
+    border-color: #4caf50;
+    color: #1b5e20;
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.98);
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  :host-context(.dark-theme) & {
+    background: rgba(45, 45, 45, 0.9);
+    border-color: #444;
+    color: #e0e0e0;
+
+    &:hover:not(:disabled) {
+      background: rgba(76, 175, 80, 0.15);
+      border-color: #4caf50;
+      color: #81c784;
+    }
+  }
+
+  @media (max-width: 480px) {
+    padding: 6px 14px;
+    font-size: 12px;
+    border-radius: 20px;
+  }
+}
+
+.pagination-info {
+  font-size: 13px;
+  font-weight: 400;
+  color: #666;
+  min-width: 120px;
+  text-align: center;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 20px;
+
+  :host-context(.dark-theme) & {
+    color: #aaa;
+    background: rgba(45, 45, 45, 0.6);
+    border-color: #444;
+  }
+
+  @media (max-width: 480px) {
+    font-size: 12px;
+    min-width: auto;
+    padding: 6px 10px;
+    border-radius: 16px;
+  }
+}
+
+// ============================================
 // MAIN CONTENT
 // ============================================
 .main-content {

--- a/src/app/pages/app-list/app-list.component.ts
+++ b/src/app/pages/app-list/app-list.component.ts
@@ -11,7 +11,7 @@ import {
   AfterViewInit,
 } from "@angular/core";
 import { CommonModule, isPlatformBrowser, SlicePipe } from "@angular/common";
-import { RouterModule, ActivatedRoute, Router } from "@angular/router";
+import { RouterModule, ActivatedRoute, Router, ParamMap } from "@angular/router";
 import { FormsModule } from "@angular/forms";
 import { NzGridModule } from "ng-zorro-antd/grid";
 import { NzCardModule } from "ng-zorro-antd/card";
@@ -21,15 +21,18 @@ import { NzIconModule } from "ng-zorro-antd/icon";
 import { NzButtonModule } from "ng-zorro-antd/button";
 import { NzSpinModule } from "ng-zorro-antd/spin";
 import { NzAlertModule } from "ng-zorro-antd/alert";
+import { NzSelectModule } from "ng-zorro-antd/select";
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import type { QuranApp } from "../../services/app.service";
-import { ApiService, Category } from "../../services/api.service";
+import { ApiService, App, Category } from "../../services/api.service";
 import { Title, Meta } from "@angular/platform-browser";
 import { combineLatest, of, Subject } from "rxjs";
 import {
   catchError,
+  distinctUntilChanged,
   filter,
   finalize,
+  map,
   take,
   takeUntil,
   switchMap,
@@ -40,6 +43,15 @@ import { RAMADAN_MODE } from "../../guards/ramadan-redirect.guard";
 import { OptimizedImageComponent } from "../../components/optimized-image/optimized-image.component";
 import { SafeHtmlPipe } from "../../pipes/safe-html.pipe";
 import { NavbarScrollService } from "../../services/navbar-scroll.service";
+
+type PlatformFilter = "all" | "ios" | "android" | "web";
+
+interface UrlQueryPatch {
+  q?: string | null;
+  category?: string | null;
+  platform?: string | null;
+  page?: number | null;
+}
 
 @Component({
   selector: "app-list",
@@ -56,6 +68,7 @@ import { NavbarScrollService } from "../../services/navbar-scroll.service";
     NzButtonModule,
     NzSpinModule,
     NzAlertModule,
+    NzSelectModule,
     TranslateModule,
     OptimizedImageComponent,
     SafeHtmlPipe,
@@ -93,8 +106,17 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
   private categoriesContainer: HTMLElement | null = null;
   currentLang: "en" | "ar" = "en"; // Initialize with browser language
   selectedCategory: string = "all";
+  selectedPlatform: PlatformFilter = "all";
+  currentPage = 1;
+  serverTotalCount = 0;
+  serverHasNext = false;
+  serverHasPrevious = false;
+  isServerFetching = false;
+  readonly platformFilters: PlatformFilter[] = ["all", "ios", "android", "web"];
   isDarkMode = false;
   private destroy$ = new Subject<void>();
+  private readonly searchInput$ = new Subject<string>();
+  private readonly pageSize = 20;
   private isInitialLoad = true;
   // Cache for star arrays to prevent NG0100 errors from creating new references on each change detection
   private starArrayCache = new Map<number, { fillPercent: number }[]>();
@@ -178,6 +200,12 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
     // Load categories and apps from API
     this.loadData();
 
+    // Sync filter state from initial URL before subscriptions fire
+    this.syncFilterStateFromUrl(
+      this.route.snapshot.paramMap,
+      this.route.snapshot.queryParamMap,
+    );
+
     // Handle smart_search query param from navbar search
     this.route.queryParamMap
       .pipe(
@@ -193,49 +221,59 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
         }
       });
 
-    // Subscribe to route changes for category filtering
-    // Use debounceTime to prevent race conditions from rapid clicks
-    this.route.paramMap
+    // Debounced traditional search — updates URL q param after 300ms
+    this.searchInput$
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((value) => {
+        if (this.searchType !== "traditional") {
+          return;
+        }
+        this.updateUrlQueryParams({ q: value.trim() || null, page: 1 });
+      });
+
+    // URL as source of truth for traditional browse/search
+    combineLatest([this.route.paramMap, this.route.queryParamMap])
       .pipe(
         debounceTime(50),
-        switchMap((params) => {
-          const lang = params.get("lang");
-          const category = params.get("category");
+        switchMap(([paramMap, queryMap]) => {
+          if (queryMap.has("smart_search") || this.searchType === "smart") {
+            return of(null);
+          }
 
+          const lang = paramMap.get("lang");
           if (lang && (lang === "ar" || lang === "en")) {
             this.currentLang = lang as "en" | "ar";
-            // Ensure TranslateService uses the correct language
             if (this.translateService.currentLang !== lang) {
               this.translateService.use(lang);
             }
           }
 
-          // Set the selected category
-          this.selectedCategory = category ? category.toLowerCase() : "all";
+          this.syncFilterStateFromUrl(paramMap, queryMap);
 
-          // Wait for apps to be loaded before filtering
+          if (this.isServerDrivenMode()) {
+            return this.fetchServerAppsObservable();
+          }
+
           return this.apiService.apps$.pipe(
-            filter((apps) => apps.length > 0),
+            filter((apps) => apps.length > 0 || this.initialLoadComplete),
             take(1),
-            switchMap((apiApps) => {
-              // Update apps from the observable directly to avoid race condition
+            map((apiApps) => {
               this.apps = apiApps.map((app) =>
                 this.apiService.formatAppForDisplay(app),
               );
-              if (this.selectedCategory === "all") {
-                this.filteredApps = this.apps;
-              } else {
-                this.filterByCategory(this.selectedCategory);
-              }
-              return of(params);
+              this.filteredApps = this.apps;
+              this.hasMoreApps = this.apps.length < this.totalAppsCount;
+              return null;
             }),
           );
         }),
         takeUntil(this.destroy$),
       )
       .subscribe(() => {
-        // Scroll to top of page when route changes (browser only)
-        // Skip on initial load to prevent snapping user back to top during loading
         if (isPlatformBrowser(this.platformId)) {
           if (this.isInitialLoad) {
             this.isInitialLoad = false;
@@ -243,23 +281,21 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
             window.scrollTo({ top: 0, behavior: "auto" });
           }
 
-          // Scroll selected category into view (horizontally within categories section)
           setTimeout(() => this.scrollSelectedCategoryIntoView(), 100);
         }
 
-        // Update SEO data after apps and route parameters are set
+        this.updateNavbarSearchState();
         this.updateSeoData();
       });
 
-    // Subscribe to apps from API service for reactive updates
+    // Subscribe to apps from API service for reactive updates (home browse mode)
     this.apiService.apps$
       .pipe(takeUntil(this.destroy$))
       .subscribe((apiApps) => {
         this.apps = apiApps.map((app) =>
           this.apiService.formatAppForDisplay(app),
         );
-        // If no category is selected, update filtered apps
-        if (this.selectedCategory === "all" && !this.searchQuery.trim()) {
+        if (!this.isServerDrivenMode()) {
           this.filteredApps = this.apps;
         }
       });
@@ -302,8 +338,9 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
       return;
     }
 
-    // Handle infinite scroll (only when not searching and not in smart search mode)
+    // Handle infinite scroll (home browse only — not server-driven or smart search)
     if (
+      !this.isServerDrivenMode() &&
       !this.searchQuery.trim() &&
       !this.isSmartSearching &&
       this.hasMoreApps &&
@@ -426,18 +463,39 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
       });
   }
 
-  /** Fires on every keystroke — only does local filtering (no smart search animation) */
+  onSearchTypeChange(type: "traditional" | "smart"): void {
+    this.searchType = type;
+    if (type === "traditional") {
+      this.isSmartSearchActive = false;
+      this.smartSearchHasMore = false;
+      this.isSmartSearching = false;
+      this.suggestedQuery = null;
+      this.syncFilterStateFromUrl(
+        this.route.snapshot.paramMap,
+        this.route.snapshot.queryParamMap,
+      );
+      if (this.isServerDrivenMode()) {
+        this.fetchServerAppsObservable()
+          .pipe(takeUntil(this.destroy$))
+          .subscribe();
+      } else {
+        this.filteredApps = this.apps;
+        this.searchExecuted = false;
+      }
+    }
+    this.updateNavbarSearchState();
+  }
+
+  /** Fires on every keystroke — debounced URL update for traditional search */
   onTypingSearch() {
     if (this.searchType === "traditional") {
       this.isSmartSearchActive = false;
       this.smartSearchHasMore = false;
-      this.applyCategoryAndSearchFilters();
+      this.searchInput$.next(this.searchQuery);
     }
-    // Sync search query with navbar
     this.navbarScrollService.updateSearchState({
       searchQuery: this.searchQuery,
     });
-    // For smart search, do nothing on typing — wait for button click / Enter
   }
 
   /** Fires on button click or Enter key */
@@ -445,27 +503,27 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
     this.suggestedQuery = null;
     const query = this.searchQuery.trim();
 
-    // If query is empty, reset infinite scroll state and respect current category filter
-    if (!query) {
-      this.isSmartSearching = false;
-      this.searchExecuted = false;
-      this.isSmartSearchActive = false;
-      this.smartSearchHasMore = false;
-      // Reset infinite scroll state for non-search views
-      this.isLoadingMore = false;
-      this.hasMoreApps = true;
-      this.totalAppsCount = 0;
-      this.applyCategoryAndSearchFilters();
-      return;
-    }
-
     if (this.searchType === "smart") {
+      if (!query) {
+        this.isSmartSearching = false;
+        this.searchExecuted = false;
+        this.isSmartSearchActive = false;
+        this.smartSearchHasMore = false;
+        this.isLoadingMore = false;
+        this.hasMoreApps = true;
+        this.totalAppsCount = 0;
+        if (!this.isServerDrivenMode()) {
+          this.filteredApps = this.apps;
+        }
+        return;
+      }
+
       this.isSmartSearching = true;
       this.searchExecuted = false;
       this.isSmartSearchActive = true;
       this.smartSearchPage = 1;
       this.filteredApps = [];
-      const filters: any = {};
+      const filters: { category?: string } = {};
       if (this.selectedCategory !== "all") {
         filters.category = this.selectedCategory;
       }
@@ -473,7 +531,7 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
         .pipe(takeUntil(this.destroy$))
         .subscribe({
           next: (response) => {
-            const results = (response.results || []).map((app: any) =>
+            const results = (response.results || []).map((app: App) =>
               this.apiService.formatAppForDisplay(app),
             );
             this.filteredApps = results;
@@ -493,16 +551,26 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
       return;
     }
 
-    // Local, tolerant search on already-loaded apps (avoids strict backend matching)
+    // Traditional — update URL immediately (server fetch triggered by query param subscription)
+    this.isSmartSearchActive = false;
+    this.smartSearchHasMore = false;
+    this.isSmartSearching = false;
+
+    if (!query) {
+      this.searchExecuted = false;
+      this.updateUrlQueryParams({ q: null, page: 1 });
+      return;
+    }
+
     this.searchExecuted = true;
-    this.applyCategoryAndSearchFilters();
+    this.updateUrlQueryParams({ q: query, page: 1 });
   }
 
   loadMoreSmartResults(): void {
     if (!this.smartSearchHasMore || this.isSmartSearching) return;
     this.isSmartSearching = true;
     this.smartSearchPage++;
-    const filters: any = {};
+    const filters: { category?: string } = {};
     if (this.selectedCategory !== 'all') {
       filters.category = this.selectedCategory;
     }
@@ -510,7 +578,7 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (response) => {
-          const results = (response.results || []).map((app: any) =>
+          const results = (response.results || []).map((app: App) =>
             this.apiService.formatAppForDisplay(app)
           );
           this.filteredApps = [...this.filteredApps, ...results];
@@ -527,34 +595,92 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   onCategoryChipClick(slug: string): void {
-    this.selectedCategory = slug;
-    // Reset infinite scroll state on category change
+    if (this.searchType === "smart" && this.isSmartSearchActive && this.searchQuery.trim()) {
+      this.selectedCategory = slug;
+      this.onSearch();
+      return;
+    }
+
+    const queryParams: Record<string, string | number | null> = { page: null };
+
+    if (this.searchQuery.trim()) {
+      queryParams["q"] = this.searchQuery.trim();
+    }
+    if (this.selectedPlatform !== "all") {
+      queryParams["platform"] = this.selectedPlatform;
+    }
+
+    const onAppsRoute = this.isAppsListRoute();
+
+    if (slug === "all") {
+      queryParams["category"] = null;
+      const route = onAppsRoute
+        ? ["/", this.currentLang, "apps"]
+        : ["/", this.currentLang];
+      this.router.navigate(route, {
+        queryParams,
+        queryParamsHandling: "merge",
+      });
+    } else if (onAppsRoute) {
+      queryParams["category"] = slug;
+      this.router.navigate(["/", this.currentLang, "apps"], {
+        queryParams,
+        queryParamsHandling: "merge",
+      });
+    } else {
+      queryParams["category"] = null;
+      this.router.navigate(["/", this.currentLang, slug], {
+        queryParams,
+        queryParamsHandling: "merge",
+      });
+    }
+
     this.isLoadingMore = false;
     this.hasMoreApps = true;
-    this.totalAppsCount = 0;
-    if (slug === 'all') {
-      this.isSmartSearchActive = false;
-      this.filteredApps = this.apps;
-    } else {
-      this.filterByCategory(slug);
-    }
-    const route = slug === 'all'
-      ? ['/', this.currentLang]
-      : ['/', this.currentLang, slug];
-    this.router.navigate(route);
   }
 
-  filterByCategory(category: string) {
-    this.selectedCategory = category.toLowerCase();
-    // Reset infinite scroll state when category changes
-    this.isLoadingMore = false;
-    this.hasMoreApps = true;
-    this.totalAppsCount = 0;
-    if (this.isSmartSearchActive && this.searchQuery.trim()) {
-      this.onSearch();
-    } else {
-      this.applyCategoryAndSearchFilters();
+  onPlatformChange(platform: PlatformFilter): void {
+    if (this.searchType === "smart") {
+      return;
     }
+    this.selectedPlatform = platform;
+    this.updateUrlQueryParams({
+      platform: platform === "all" ? null : platform,
+      page: 1,
+    });
+  }
+
+  goToPage(page: number): void {
+    const totalPages = this.getTotalPages();
+    if (page < 1 || page > totalPages) {
+      return;
+    }
+    this.updateUrlQueryParams({ page: page > 1 ? page : null });
+    if (isPlatformBrowser(this.platformId)) {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  }
+
+  getTotalPages(): number {
+    return Math.max(1, Math.ceil(this.serverTotalCount / this.pageSize));
+  }
+
+  getResultCount(): number {
+    return this.isServerDrivenMode()
+      ? this.serverTotalCount
+      : this.filteredApps.length;
+  }
+
+  isServerDrivenMode(): boolean {
+    if (this.searchType === "smart") {
+      return false;
+    }
+    return (
+      !!this.searchQuery.trim() ||
+      this.selectedCategory !== "all" ||
+      this.selectedPlatform !== "all" ||
+      this.currentPage > 1
+    );
   }
 
   retryLoadData() {
@@ -567,7 +693,7 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
    * Load the next page of apps via infinite scroll.
    */
   loadMoreApps(): void {
-    if (this.isLoadingMore || !this.hasMoreApps) return;
+    if (this.isServerDrivenMode() || this.isLoadingMore || !this.hasMoreApps) return;
     this.isLoadingMore = true;
 
     this.apiService.loadNextPage()
@@ -575,7 +701,6 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
       .subscribe({
         next: (totalCount) => {
           this.totalAppsCount = totalCount;
-          // Check if we've loaded all apps
           if (this.apps.length >= totalCount) {
             this.hasMoreApps = false;
           }
@@ -590,68 +715,119 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
       });
   }
 
-  /**
-   * Apply current category + search query to the in-memory apps list.
-   * This allows us to normalize Arabic text and be tolerant to hamza/diacritics.
-   */
-  private applyCategoryAndSearchFilters(): void {
-    const query = this.searchQuery.trim();
-    const hasQuery = !!query;
+  private syncFilterStateFromUrl(
+    paramMap: ParamMap,
+    queryMap: ParamMap,
+  ): void {
+    this.searchQuery = queryMap.get("q") || "";
+    this.selectedPlatform = this.parsePlatformFilter(queryMap.get("platform"));
 
-    this.filteredApps = this.apps.filter((app) => {
-      // Category filter
-      const inCategory =
-        this.selectedCategory === "all"
-          ? true
-          : (app.categories || [])
-              .map((c) => c.toLowerCase())
-              .includes(this.selectedCategory);
+    const page = parseInt(queryMap.get("page") || "1", 10);
+    this.currentPage = Number.isNaN(page) || page < 1 ? 1 : page;
 
-      if (!inCategory) return false;
+    this.selectedCategory = this.resolveEffectiveCategory(queryMap, paramMap);
+  }
 
-      // Search filter
-      return hasQuery ? this.isAppInSearchResults(app) : true;
+  private resolveEffectiveCategory(
+    queryMap: ParamMap,
+    paramMap: ParamMap,
+  ): string {
+    const queryCategory = queryMap.get("category");
+    if (queryCategory) {
+      return queryCategory.toLowerCase();
+    }
+    const routeCategory = paramMap.get("category");
+    if (routeCategory) {
+      return routeCategory.toLowerCase();
+    }
+    return "all";
+  }
+
+  private parsePlatformFilter(value: string | null): PlatformFilter {
+    const valid: PlatformFilter[] = ["all", "ios", "android", "web"];
+    if (value && valid.includes(value as PlatformFilter)) {
+      return value as PlatformFilter;
+    }
+    return "all";
+  }
+
+  private isAppsListRoute(): boolean {
+    const segments = this.router.url.split("?")[0].split("/").filter(Boolean);
+    return segments.length >= 2 && segments[1] === "apps";
+  }
+
+  private updateUrlQueryParams(
+    patch: UrlQueryPatch,
+    options?: { replaceUrl?: boolean },
+  ): void {
+    const queryParams: Record<string, string | number | null> = {};
+
+    if ("q" in patch) {
+      queryParams["q"] = patch.q?.trim() ? patch.q.trim() : null;
+    }
+    if ("category" in patch) {
+      queryParams["category"] =
+        patch.category && patch.category !== "all" ? patch.category : null;
+    }
+    if ("platform" in patch) {
+      queryParams["platform"] =
+        patch.platform && patch.platform !== "all" ? patch.platform : null;
+    }
+    if ("page" in patch) {
+      queryParams["page"] =
+        patch.page && patch.page > 1 ? patch.page : null;
+    }
+
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams,
+      queryParamsHandling: "merge",
+      replaceUrl: options?.replaceUrl ?? false,
     });
   }
 
-  /**
-   * Normalize text to make search tolerant for Arabic spelling variants
-   * (e.g. "القران" vs "القرآن") and case-insensitive in English.
-   */
-  private normalizeText(text: string): string {
-    if (!text) return "";
+  private fetchServerAppsObservable() {
+    this.isServerFetching = true;
 
-    let normalized = text.toLowerCase();
+    const params: {
+      search?: string;
+      category?: string;
+      platform?: string;
+      page: number;
+      page_size: number;
+    } = {
+      page: this.currentPage,
+      page_size: this.pageSize,
+    };
 
-    // Normalize common Arabic variants
-    normalized = normalized
-      // Different forms of alif with hamza/mand
-      .replace(/[أإآ]/g, "ا")
-      // taa marbuta to ha
-      .replace(/ة/g, "ه")
-      // yaa/aleph maqsura
-      .replace(/ى/g, "ي")
-      // remove common Arabic diacritics
-      .replace(/[\u064B-\u0652]/g, "");
+    if (this.searchQuery.trim()) {
+      params.search = this.searchQuery.trim();
+    }
+    if (this.selectedCategory !== "all") {
+      params.category = this.selectedCategory;
+    }
+    if (this.selectedPlatform !== "all") {
+      params.platform = this.selectedPlatform;
+    }
 
-    return normalized;
-  }
-
-  private isAppInSearchResults(app: QuranApp): boolean {
-    const query = this.searchQuery.trim();
-    if (!query) return true;
-
-    const searchNorm = this.normalizeText(query);
-    const nameEn = this.normalizeText(app.Name_En || "");
-    const nameAr = this.normalizeText(app.Name_Ar || "");
-    const descEn = this.normalizeText(app.Short_Description_En || "");
-    const descAr = this.normalizeText(app.Short_Description_Ar || "");
-
-    return (
-      nameEn.includes(searchNorm) ||
-      nameAr.includes(searchNorm) ||
-      descEn.includes(searchNorm) ||
-      descAr.includes(searchNorm)
+    return this.apiService.getApps(params).pipe(
+      catchError(() =>
+        of({ count: 0, next: null, previous: null, results: [] }),
+      ),
+      map((response) => {
+        this.filteredApps = response.results.map((app) =>
+          this.apiService.formatAppForDisplay(app),
+        );
+        this.serverTotalCount = response.count || 0;
+        this.serverHasNext = !!response.next;
+        this.serverHasPrevious = !!response.previous;
+        this.searchExecuted = !!this.searchQuery.trim();
+        return response;
+      }),
+      finalize(() => {
+        this.isServerFetching = false;
+        this.cdr.detectChanges();
+      }),
     );
   }
 

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -206,10 +206,10 @@ export class ApiService {
     }
 
     // For filtered requests (search, category, etc.), return single page
+    // without updating the home-page apps cache used by infinite scroll
     return this.http.get<AppListResponse>(`${this.apiUrl}/apps/`, { params: httpParams }).pipe(
-      tap(response => {
+      tap(() => {
         this.setLoading(false);
-        this.appsSubject.next(response.results);
       }),
       catchError(error => {
         this.setError('Failed to load applications. Please try again later.');

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -87,6 +87,20 @@
     "badges": {
       "featured": "مميز",
       "new": "جديد"
+    },
+    "filters": {
+      "platform": {
+        "label": "المنصة",
+        "all": "الكل",
+        "ios": "iOS",
+        "android": "أندرويد",
+        "web": "ويب"
+      },
+      "pagination": {
+        "prev": "السابق",
+        "next": "التالي",
+        "page": "صفحة {{current}} من {{total}}"
+      }
     }
   },
   "developer": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -87,6 +87,20 @@
     "badges": {
       "featured": "Featured",
       "new": "New"
+    },
+    "filters": {
+      "platform": {
+        "label": "Platform",
+        "all": "All",
+        "ios": "iOS",
+        "android": "Android",
+        "web": "Web"
+      },
+      "pagination": {
+        "prev": "Previous",
+        "next": "Next",
+        "page": "Page {{current}} of {{total}}"
+      }
     }
   },
   "developer": {

--- a/src/global_styles.css
+++ b/src/global_styles.css
@@ -201,3 +201,73 @@ nz-layout.app-layout::after {
   margin: 0 !important;
   margin-inline-end: 6px !important;
 }
+
+/* App list — platform select dropdown (CDK overlay on body) */
+.app-list-platform-dropdown.ant-select-dropdown {
+  border-radius: 16px;
+  padding: 6px;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+.app-list-platform-dropdown .rc-virtual-list,
+.app-list-platform-dropdown .rc-virtual-list-holder {
+  max-height: 184px !important;
+  height: 184px !important;
+}
+
+.app-list-platform-dropdown .rc-virtual-list-holder-inner {
+  height: auto !important;
+  max-height: none !important;
+}
+
+.app-list-platform-dropdown .ant-select-dropdown-menu {
+  max-height: none !important;
+  overflow: hidden !important;
+}
+
+.app-list-platform-dropdown .rc-virtual-list-scrollbar,
+.app-list-platform-dropdown .rc-virtual-list-scrollbar-thumb {
+  display: none !important;
+}
+
+.app-list-platform-dropdown .ant-select-item,
+.app-list-platform-dropdown .ant-select-item-option {
+  border-radius: 12px;
+  font-size: 13px;
+  font-weight: 400;
+  color: #1a1a1a;
+  min-height: 40px;
+  line-height: 40px;
+  padding: 0 12px;
+}
+
+.app-list-platform-dropdown .ant-select-item-option-active:not(.ant-select-item-option-disabled) {
+  background: rgba(76, 175, 80, 0.08);
+}
+
+.app-list-platform-dropdown .ant-select-item-option-selected:not(.ant-select-item-option-disabled) {
+  background: #e8f5e9;
+  color: #1b5e20;
+  font-weight: 500;
+}
+
+.dark-theme .app-list-platform-dropdown.ant-select-dropdown {
+  background: rgba(45, 45, 45, 0.98);
+  border-color: #444;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+}
+
+.dark-theme .app-list-platform-dropdown .ant-select-item {
+  color: #e0e0e0;
+}
+
+.dark-theme .app-list-platform-dropdown .ant-select-item-option-active:not(.ant-select-item-option-disabled) {
+  background: rgba(76, 175, 80, 0.1);
+}
+
+.dark-theme .app-list-platform-dropdown .ant-select-item-option-selected:not(.ant-select-item-option-disabled) {
+  background: rgba(76, 175, 80, 0.15);
+  color: #81c784;
+}


### PR DESCRIPTION
Implements #294: server-driven traditional search on the app list with debounced input, URL-synced filters, and pagination. Smart search and home infinite scroll are unchanged.

## Type of Change

- [x] New feature

Closes #294

## What changed

- **Search:** 300ms debounce → updates `?q=` and resets `page=1`
- **URL filters:** `q`, `category`, `platform`, `page` drive `getApps()` server requests
- **UI:** Category chips (unchanged routes), platform dropdown in pill card, prev/next pagination
- **ApiService:** Filtered `getApps()` no longer overwrites home-page cache
- **i18n:** `appList.filters.platform.*`, `appList.filters.pagination.*` (en/ar)
- **Styles:** Platform dropdown overlay in `global_styles.css`

## Testing

- [x] `/en` — infinite scroll still works
- [x] `/en/mushaf` — server category filter
- [x] `/en/apps?q=...&category=...&platform=...&page=2`
- [x] `/ar/...` — RTL
- [x] Smart search (`?smart_search=`) unchanged
- [x] `npm run build:develop` passes

## PR Checklist

- [x] Both languages tested
- [x] Dark mode verified
- [x] Mobile responsive