### PR TITLE
feat(search): auto-correct keyboard layout mismatches in search (#302)

### DIFF
--- a/src/app/pages/app-list/app-list.component.ts
+++ b/src/app/pages/app-list/app-list.component.ts
@@ -40,6 +40,7 @@ import { RAMADAN_MODE } from "../../guards/ramadan-redirect.guard";
 import { OptimizedImageComponent } from "../../components/optimized-image/optimized-image.component";
 import { SafeHtmlPipe } from "../../pipes/safe-html.pipe";
 import { NavbarScrollService } from "../../services/navbar-scroll.service";
+import { convertKeyboardLayout, isArabicQuery, isLatinQuery } from "../../utils/keyboard-layout.util";
 
 @Component({
   selector: "app-list",
@@ -69,6 +70,7 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
   apps: QuranApp[] = [];
   filteredApps: QuranApp[] = [];
   searchQuery: string = "";
+  activeSearchQuery: string = "";
   searchType: "traditional" | "smart" = "traditional";
   isSmartSearching = false;
   searchExecuted = false;
@@ -469,6 +471,7 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
       if (this.selectedCategory !== "all") {
         filters.category = this.selectedCategory;
       }
+      this.activeSearchQuery = query;
       this.apiService.searchHybrid(query, filters, 1, 20)
         .pipe(takeUntil(this.destroy$))
         .subscribe({
@@ -476,6 +479,37 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
             const results = (response.results || []).map((app: any) =>
               this.apiService.formatAppForDisplay(app),
             );
+            
+            // If smart search got 0 results, try keyboard layout conversion
+            if (results.length === 0 && (isArabicQuery(query) || isLatinQuery(query))) {
+              const converted = convertKeyboardLayout(query);
+              if (converted && converted !== query) {
+                this.activeSearchQuery = converted;
+                this.apiService.searchHybrid(converted, filters, 1, 20)
+                  .pipe(takeUntil(this.destroy$))
+                  .subscribe({
+                    next: (correctedResponse) => {
+                      const correctedResults = (correctedResponse.results || []).map((app: any) =>
+                        this.apiService.formatAppForDisplay(app),
+                      );
+                      this.filteredApps = correctedResults;
+                      this.smartSearchTotal = correctedResponse.count || 0;
+                      this.smartSearchHasMore = !!correctedResponse.next;
+                      this.suggestedQuery = correctedResponse.suggested_query || null;
+                      this.isSmartSearching = false;
+                      this.searchExecuted = true;
+                      this.navbarScrollService.updateSearchState({ isSearching: false });
+                      this.cdr.detectChanges();
+                    },
+                    error: () => {
+                      this.isSmartSearching = false;
+                      this.cdr.detectChanges();
+                    }
+                  });
+                return;
+              }
+            }
+
             this.filteredApps = results;
             this.smartSearchTotal = response.count || 0;
             this.smartSearchHasMore = !!response.next;
@@ -506,7 +540,7 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
     if (this.selectedCategory !== 'all') {
       filters.category = this.selectedCategory;
     }
-    this.apiService.searchHybrid(this.searchQuery.trim(), filters, this.smartSearchPage, 20)
+    this.apiService.searchHybrid(this.activeSearchQuery || this.searchQuery.trim(), filters, this.smartSearchPage, 20)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (response) => {
@@ -610,8 +644,24 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
       if (!inCategory) return false;
 
       // Search filter
-      return hasQuery ? this.isAppInSearchResults(app) : true;
+      return hasQuery ? this.isAppInSearchResults(app, query) : true;
     });
+
+    // If no results and query is purely one script, try keyboard layout conversion
+    if (this.filteredApps.length === 0 && hasQuery && (isArabicQuery(query) || isLatinQuery(query))) {
+      const converted = convertKeyboardLayout(query);
+      if (converted && converted !== query) {
+        this.filteredApps = this.apps.filter((app) => {
+          const inCategory =
+            this.selectedCategory === "all"
+              ? true
+              : (app.categories || [])
+                  .map((c) => c.toLowerCase())
+                  .includes(this.selectedCategory);
+          return inCategory && this.isAppInSearchResults(app, converted);
+        });
+      }
+    }
   }
 
   /**
@@ -637,8 +687,7 @@ export class AppListComponent implements OnInit, OnDestroy, AfterViewInit {
     return normalized;
   }
 
-  private isAppInSearchResults(app: QuranApp): boolean {
-    const query = this.searchQuery.trim();
+  private isAppInSearchResults(app: QuranApp, query: string): boolean {
     if (!query) return true;
 
     const searchNorm = this.normalizeText(query);

--- a/src/app/utils/keyboard-layout.util.ts
+++ b/src/app/utils/keyboard-layout.util.ts
@@ -1,0 +1,132 @@
+const englishToArabic: Record<string, string> = {
+  q: 'ض',
+  w: 'ص',
+  e: 'ث',
+  r: 'ق',
+  t: 'ف',
+  y: 'غ',
+  u: 'ع',
+  i: 'ه',
+  o: 'خ',
+  p: 'ح',
+  '[': 'ج',
+  ']': 'د',
+
+  a: 'ش',
+  s: 'س',
+  d: 'ي',
+  f: 'ب',
+  g: 'ل',
+  h: 'ا',
+  j: 'ت',
+  k: 'ن',
+  l: 'م',
+  ';': 'ك',
+  "'": 'ط',
+
+  z: 'ئ',
+  x: 'ء',
+  c: 'ؤ',
+  v: 'ر',
+  b: 'لا',
+  n: 'ى',
+  m: 'ة',
+  ',': 'و',
+  '.': 'ز',
+  '/': 'ظ',
+};
+
+const arabicToEnglish: Record<string, string> = {
+  'ض': 'q',
+  'ص': 'w',
+  'ث': 'e',
+  'ق': 'r',
+  'ف': 't',
+  'غ': 'y',
+  'ع': 'u',
+  'ه': 'i',
+  'خ': 'o',
+  'ح': 'p',
+  'ج': '[',
+  'د': ']',
+
+  'ش': 'a',
+  'س': 's',
+  'ي': 'd',
+  'ب': 'f',
+  'ل': 'g',
+  'ا': 'h',
+  'ت': 'j',
+  'ن': 'k',
+  'م': 'l',
+  'ك': ';',
+  'ط': "'",
+
+  'ئ': 'z',
+  'ء': 'x',
+  'ؤ': 'c',
+  'ر': 'v',
+  'لا': 'b',
+  'ى': 'n',
+  'ة': 'm',
+  'و': ',',
+  'ز': '.',
+  'ظ': '/',
+};
+
+/**
+ * Detects if a query is purely Arabic script.
+ */
+export function isArabicQuery(query: string): boolean {
+  return /^[\u0600-\u06FF\s]+$/.test(query);
+}
+
+/**
+ * Detects if a query is purely Latin (English) script,
+ * including punctuation keys that map to Arabic characters
+ * on the Arabic keyboard layout: [ ] ; ' , . /
+ */
+export function isLatinQuery(query: string): boolean {
+  return /^[a-zA-Z\s[\];',.\/]+$/.test(query);
+}
+
+/**
+ * Converts a query typed in the wrong keyboard layout to the intended layout.
+ *
+ * - Arabic chars typed on English layout → converts to English
+ * - English chars typed on Arabic layout → converts to Arabic
+ *
+ * Returns the converted string, or an empty string if no conversion is needed
+ * or the query is not purely one script.
+ */
+export function convertKeyboardLayout(query: string): string {
+  if (!query) return '';
+
+  if (isArabicQuery(query)) {
+    return convertArabicToEnglish(query);
+  }
+
+  if (isLatinQuery(query)) {
+    return convertEnglishToArabic(query);
+  }
+
+  // Mixed-script query — not a layout mistake, skip conversion
+  return '';
+}
+
+function convertEnglishToArabic(query: string): string {
+  return query
+    .toLowerCase()
+    .split('')
+    .map((char) => englishToArabic[char] ?? char)
+    .join('');
+}
+
+function convertArabicToEnglish(query: string): string {
+  // Handle multi-char Arabic tokens (e.g. 'لا') before single chars
+  let result = query;
+  for (const [arabic, english] of Object.entries(arabicToEnglish)) {
+    result = result.split(arabic).join(english);
+  }
+  return result;
+}


### PR DESCRIPTION
## Description

Users sometimes search with the wrong keyboard layout active — for example, typing 'غخعسسثب' when they meant 'youssef', or 's,vi' when they meant 'سوره'. This change detects those cases and retries the search with the correctly mapped query automatically, without any action from the user. It works for both traditional and smart search modes.

The conversion only triggers when the query returns no results and is written entirely in one script (all Arabic or all Latin), which prevents false results on valid queries that simply have no matches.

## Type of Change
- [x] New feature

## Testing
- [x] Manual testing completed

| Query typed | Intended | Outcome |
|-------------|----------|---------|
| `غخعسسثب` on Arabic keyboard | `youssef` | Results found correctly |
| `s,vi` on English keyboard | `سوره` | Results found correctly |
| `lwpt` on English keyboard | `مصحف` | Results found correctly |
| Valid word with no matching app | — | Empty state, no false conversion |

## Screenshots
<img width="1849" height="891" alt="image" src="https://github.com/user-attachments/assets/94db4755-043b-4086-a9e4-04e8d30bc0e9" />

<img width="1849" height="896" alt="image" src="https://github.com/user-attachments/assets/925ee91c-9495-412a-80c3-2b15b8e8bdc8" />

<img width="1848" height="895" alt="image" src="https://github.com/user-attachments/assets/ebec644b-2b0b-49b9-a305-bbd5d532ad96" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved search to recognize Arabic and Latin keyboard-layout mismatches.
  - Automatically retries searches with a converted query when no results are found.
  - Local filtering now applies the same keyboard-layout correction.
- **Bug Fixes**
  - Search pagination now remains consistent after query correction.
  - Corrected search results and related metadata are preserved across subsequent pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->