### PR TITLE
feat(app-detail): keyboard and swipe navigation for the screenshot lightbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -498,7 +498,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.15.tgz",
       "integrity": "sha512-ikyKfhkxoqQA6JcBN0B9RaN6369sM1XYX81Id0lI58dmWCe7gYfrTp8ejqxxKftl514psQO3pkW8Gn1nJ131Gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -713,7 +712,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.15.tgz",
       "integrity": "sha512-k4mCXWRFiOHK3bUKfWkRQQ8KBPxW8TAJuKLYCsSHPCpMz6u0eA1F0VlrnOkZVKWPI792fOaEAWH2Y4PTaXlUHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -730,7 +728,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.15.tgz",
       "integrity": "sha512-lMicIAFAKZXa+BCZWs3soTjNQPZZXrF/WMVDinm8dQcggNarnDj4UmXgKSyXkkyqK5SLfnLsXVzrX6ndVT6z7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -744,7 +741,6 @@
       "integrity": "sha512-8sJoxodxsfyZ8eJ5r6Bx7BCbazXYgsZ1+dE8t5u5rTQ6jNggwNtYEzkyReoD5xvP+MMtRkos3xpwq4rtFnpI6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.3",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -777,7 +773,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.15.tgz",
       "integrity": "sha512-NMbX71SlTZIY9+rh/SPhRYFJU0pMJYW7z/TBD4lqiO+b0DTOIg1k7Pg9ydJGqSjFO1Z4dQaA6TteNuF99TJCNw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -803,7 +798,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.15.tgz",
       "integrity": "sha512-gS5hQkinq52pm/7mxz4yHPCzEcmRWjtUkOVddPH0V1BW/HMni/p4Y6k2KqKBeGb9p8S5EAp6PDxDVLOPukp3mg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -822,7 +816,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.15.tgz",
       "integrity": "sha512-TxRM/wTW/oGXv/3/Iohn58yWoiYXOaeEnxSasiGNS1qhbkcKtR70xzxW6NjChBUYAixz2ERkLURkpx3pI8Q6Dw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -863,7 +856,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-20.3.15.tgz",
       "integrity": "sha512-OB3/ztCREeZ0pe2P+43Nah9Xq2Y79fN6mbsOY1JwwYxkM8ZN1WkSP11xlHHwAcoquHP7uFPhXwJqgTHBqGqkcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0",
         "xhr2": "^0.2.0"
@@ -884,7 +876,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.15.tgz",
       "integrity": "sha512-6+qgk8swGSoAu7ISSY//GatAyCP36hEvvUgvjbZgkXLLH9yUQxdo77ij05aJ5s0OyB25q/JkqS8VTY0z1yE9NQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -903,7 +894,6 @@
       "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-20.3.15.tgz",
       "integrity": "sha512-HCptODPVWg30XJwSueOz2zqsJjQ1chSscTs7FyIQcfuCTTthO35Lvz2Gtct8/GNHel9QNvvVwA5jrLjsU4dt1A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -923,7 +913,6 @@
       "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-20.3.12.tgz",
       "integrity": "sha512-liIxrlozOkcx+6qkMb0rFcKjo32aRtUI/U7TQ+1KA1XZrIk97aTjHEpq0KhBMjNlOt/xwrlUARDXjS5au5kP5g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1007,7 +996,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3315,7 +3303,6 @@
       "integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.2.1",
         "@inquirer/confirm": "^5.1.14",
@@ -4611,7 +4598,6 @@
       "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-15.0.0.tgz",
       "integrity": "sha512-Am5uiuR0bOOxyoercDnAA3rJVizo4RRqJHo8N3RqJ+XfzVP/I845yEnMADykOHvM6HkVm4SZSnJBOiz0Anx5BA==",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "engines": {
         "node": "^16.13.0 || >=18.10.0"
       },
@@ -5940,7 +5926,6 @@
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
@@ -6264,7 +6249,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6330,7 +6314,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6795,7 +6778,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -9285,7 +9267,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9407,7 +9388,6 @@
       "integrity": "sha512-kdTwsyRuncDfjEs0DlRILWNvxhDG/Zij4YLO4TMJgDLW+8OzpfkdPnRgrsRuY1o+oaxJGWsps5f/RVBgGmmN0w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -9498,7 +9478,6 @@
       "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^4.0.0",
         "colorette": "^2.0.20",
@@ -11278,7 +11257,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11918,7 +11896,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11957,7 +11934,6 @@
       "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -12950,7 +12926,6 @@
       "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.14.0",
@@ -13094,8 +13069,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "3.1.0",
@@ -13139,7 +13113,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13340,7 +13313,6 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -13465,7 +13437,6 @@
       "integrity": "sha512-4JLXU0tD6OZNVqlwzm3HGEhAHufSiyv+skb7q0d2367VDMzrU1Q/ZeepvkcHH0rZie6uqEtTQQe0OEOOluH3Mg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -13545,7 +13516,6 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -14096,7 +14066,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -14115,8 +14084,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -41,6 +41,14 @@
         >
           {{ "header.contact" | translate }}
         </a>
+        <a
+          nz-button
+          nzType="text"
+          [routerLink]="['/', currentLang, 'submit-app']"
+          class="nav-link"
+        >
+          {{ "header.submitApp" | translate }}
+        </a>
       </nav>
 
       <!-- Action Buttons - Right Side -->

--- a/src/app/pages/app-detail/app-detail.component.ts
+++ b/src/app/pages/app-detail/app-detail.component.ts
@@ -1,9 +1,11 @@
 import {
   Component,
   OnInit,
+  OnDestroy,
   AfterViewInit,
   ViewChild,
   ElementRef,
+  HostListener,
   CUSTOM_ELEMENTS_SCHEMA,
   ChangeDetectorRef,
   Inject,
@@ -27,7 +29,7 @@ import { DomSanitizer, SafeHtml, Title, Meta } from "@angular/platform-browser";
 import { NzDividerModule } from "ng-zorro-antd/divider";
 import { categories } from "../../services/applicationsData";
 import { NzRateModule } from "ng-zorro-antd/rate";
-import { NzImageModule, NzImageService } from "ng-zorro-antd/image";
+import { NzImageModule, NzImageService, NzImagePreviewRef } from "ng-zorro-antd/image";
 import { FormsModule } from "@angular/forms";
 // import function to register Swiper custom elements
 import { register } from "swiper/element/bundle";
@@ -64,7 +66,7 @@ type AppDetailStatus = 'loading' | 'success' | 'not-found' | 'error';
   styleUrls: ["./app-detail.component.scss"],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
-export class AppDetailComponent implements OnInit, AfterViewInit {
+export class AppDetailComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild("swiperContainer") swiperContainer: any;
   @ViewChild("relatedCarousel") relatedCarousel!: ElementRef<HTMLDivElement>;
 
@@ -92,6 +94,13 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
 
   hideSwiper = true;
   status: AppDetailStatus = 'loading';
+
+  // Active ng-zorro image preview opened from the screenshots carousel.
+  // Keyboard and swipe navigation are handled at document level (see handlers
+  // below) because focus usually stays on the page behind the overlay, where
+  // the preview's own key listener never fires.
+  private lightboxRef: NzImagePreviewRef | null = null;
+  private touchStart: { x: number; y: number; time: number } | null = null;
 
   constructor(
     private route: ActivatedRoute,
@@ -130,6 +139,11 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
         }, 100);
       }
     });
+  }
+
+  ngOnDestroy(): void {
+    // Don't leak the overlay (or its document handlers' target) on navigation.
+    this.closeLightbox();
   }
 
   private getBrowserLanguage(): "en" | "ar" {
@@ -450,11 +464,82 @@ export class AppDetailComponent implements OnInit, AfterViewInit {
     // Reorder images array so clicked image is first, maintaining circular order
     const reorderedImages = [...images.slice(index), ...images.slice(0, index)];
 
-    this.nzImageService.preview(reorderedImages, {
+    // nzKeyboard is disabled in favor of the component's own document-level
+    // handler below: it works regardless of overlay focus and avoids
+    // double-handling with the preview's internal listener.
+    this.lightboxRef = this.nzImageService.preview(reorderedImages, {
       nzZoom: 1,
       nzRotate: 0,
       nzNoAnimation: false,
+      nzKeyboard: false,
     });
+    // Track user-driven closes (mask click, X button) so the document
+    // handlers below stop firing once the preview is gone.
+    const previewRef = this.lightboxRef;
+    const closeSub = previewRef.previewInstance.closeClick.subscribe(() => {
+      if (this.lightboxRef === previewRef) {
+        this.lightboxRef = null;
+      }
+      closeSub.unsubscribe();
+    });
+  }
+
+  /**
+   * Close the lightbox preview if one is open.
+   */
+  closeLightbox(): void {
+    this.lightboxRef?.close();
+    this.lightboxRef = null;
+    this.touchStart = null;
+  }
+
+  /**
+   * Keyboard navigation for the lightbox: arrows switch images, Escape closes.
+   * Document-level because focus stays on the page behind the overlay.
+   */
+  @HostListener("document:keydown", ["$event"])
+  handleLightboxKeydown(event: KeyboardEvent): void {
+    if (!this.lightboxRef) return;
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      this.lightboxRef.prev();
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault();
+      this.lightboxRef.next();
+    } else if (event.key === "Escape") {
+      this.closeLightbox();
+    }
+  }
+
+  /**
+   * Touch navigation for the lightbox on mobile: a quick, mostly-horizontal
+   * swipe switches images. Thresholds keep slow drags (image panning) working.
+   */
+  @HostListener("document:touchstart", ["$event"])
+  handleLightboxTouchStart(event: TouchEvent): void {
+    if (!this.lightboxRef || event.touches.length !== 1) return;
+    const touch = event.touches[0];
+    this.touchStart = { x: touch.clientX, y: touch.clientY, time: Date.now() };
+  }
+
+  @HostListener("document:touchend", ["$event"])
+  handleLightboxTouchEnd(event: TouchEvent): void {
+    if (!this.lightboxRef || !this.touchStart || event.changedTouches.length !== 1) {
+      this.touchStart = null;
+      return;
+    }
+    const touch = event.changedTouches[0];
+    const dx = touch.clientX - this.touchStart.x;
+    const dy = touch.clientY - this.touchStart.y;
+    const dt = Date.now() - this.touchStart.time;
+    this.touchStart = null;
+    if (dt < 600 && Math.abs(dx) > 60 && Math.abs(dx) > Math.abs(dy) * 1.5) {
+      if (dx < 0) {
+        this.lightboxRef.next();
+      } else {
+        this.lightboxRef.prev();
+      }
+    }
   }
 
   // Add a method to handle category click navigation


### PR DESCRIPTION
## Summary

Completes the screenshot lightbox on the app-detail page: the overlay itself already opened
via `NzImageService`, but it could only be driven with on-screen buttons — keyboard arrows did
nothing (focus stays on the page behind the overlay, where the preview's own key listener never
fires) and there was no swipe support on mobile.

Refs #295

## Changes (`app-detail.component.ts` only)

- Track the open preview as `lightboxRef: NzImagePreviewRef | null`, cleared on user-driven
  close (mask/X via `closeClick`), on programmatic close, and on component destroy.
- Document-level `keydown` handler while open: `ArrowLeft`/`ArrowRight` switch images,
  `Escape` closes. The preview is opened with `nzKeyboard: false` so navigation has exactly
  one owner (avoids double-handling with the overlay's internal listener).
- Document-level `touchstart`/`touchend` tracking: a quick (>60px, <600ms),
  mostly-horizontal swipe switches images; slow drags (image panning) are unaffected.
- `ngOnDestroy` closes any open preview so the overlay cannot outlive the page.

## Acceptance criteria mapping

- Overlay opens on tap: pre-existing (`openLightbox` → `NzImageService.preview`), unchanged.
- Keyboard + swipe: implemented above.
- Zero layout shift: already contained — swiper slides use fixed heights at every breakpoint,
  so loading images cannot move surrounding content; no markup change needed.
- Optional video links: no video URL fields exist anywhere in the app model or backend data,
  so there is nothing to wire yet — proposing this as a follow-up once the fields exist.

## Verification

- `tsc --noEmit` clean and full `ng build` green (this repo has no unit-test runner or
  linter configured; the pre-existing prettier deviation in this file was left untouched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added keyboard navigation for image previews using the arrow keys.
  - Added Escape-key support to close the image preview.
  - Added touch swipe gestures for navigating between images.
  - Image previews now close automatically when leaving the app detail page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->